### PR TITLE
refactor: MeberSerivce#signUp 회원가입 메서드 파라미터 수정

### DIFF
--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/dto/AuctionSearchCondition.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/dto/AuctionSearchCondition.java
@@ -1,4 +1,5 @@
 package com.wootecam.luckyvickyauction.core.auction.dto;
 
+// 조회할때 조건
 public record AuctionSearchCondition() {
 }

--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/dto/CreateAuctionCommand.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/dto/CreateAuctionCommand.java
@@ -1,5 +1,7 @@
 package com.wootecam.luckyvickyauction.core.auction.dto;
 
+// 명령 단위 : 옥션 생성할때 쓰기 위한 파라미터 들
+
 import com.wootecam.luckyvickyauction.core.auction.domain.PricePolicy;
 import com.wootecam.luckyvickyauction.global.exception.BadRequestException;
 import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
@@ -16,23 +18,14 @@ import java.util.Objects;
  * @param stock                     재고 수량
  * @param maximumPurchaseLimitCount 최대 구매 제한 수량 (인당 구매 가능 수량)
  * @param pricePolicy               경매 유형 {@link PricePolicy}
- * @param variationDuration        가격 변동 주기
+ * @param variationDuration         가격 변동 주기
  * @param startedAt                 경매 시작 시간
  * @param finishedAt                경매 종료 시간
  */
 
-public record CreateAuctionCommand(
-    Long sellerId,
-    String productName,
-    long originPrice,
-    int stock,
-    int maximumPurchaseLimitCount,
-    PricePolicy pricePolicy,
-    Duration variationDuration,
-    ZonedDateTime startedAt,
-    ZonedDateTime finishedAt,
-    boolean isShowStock
-) {
+public record CreateAuctionCommand(Long sellerId, String productName, long originPrice, int stock,
+                                   int maximumPurchaseLimitCount, PricePolicy pricePolicy, Duration variationDuration,
+                                   ZonedDateTime startedAt, ZonedDateTime finishedAt, boolean isShowStock) {
     private static final String ERROR_MAX_PURCHASE_LIMIT = "최대 구매 수량 제한은 0보다 커야 합니다. 최대 구매 수량 제한: %d";
     private static final String ERROR_VARIATION_DURATION = "변동 시간 단위는 0보다 커야 합니다. 변동 시간: %s";
     private static final String ERROR_AUCTION_TIME = "경매의 시작 시간은 종료 시간보다 이전이어야 합니다. 시작 시간: %s, 종료 시간: %s";
@@ -71,7 +64,8 @@ public record CreateAuctionCommand(
 
     private void validateMaximumPurchaseLimitCount(int maximumPurchaseLimitCount) {
         if (maximumPurchaseLimitCount <= 0) {
-            throw new BadRequestException(String.format(ERROR_MAX_PURCHASE_LIMIT, maximumPurchaseLimitCount), ErrorCode.A003);
+            throw new BadRequestException(String.format(ERROR_MAX_PURCHASE_LIMIT, maximumPurchaseLimitCount),
+                    ErrorCode.A003);
         }
     }
 

--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/dto/UpdateAuctionCommand.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/dto/UpdateAuctionCommand.java
@@ -21,17 +21,17 @@ import java.util.Objects;
  * @param requestTime               사용자가 요청한 시간
  */
 public record UpdateAuctionCommand(
-    Long auctionId,
-    long originPrice,
-    int stock,
-    int maximumPurchaseLimitCount,
-    PricePolicy pricePolicy,
-    Duration variationDuration,
-    ZonedDateTime startedAt,
-    ZonedDateTime finishedAt,
-    boolean isShowStock,
-    // command meta info
-    ZonedDateTime requestTime
+        Long auctionId,
+        long originPrice,
+        int stock,
+        int maximumPurchaseLimitCount,
+        PricePolicy pricePolicy,
+        Duration variationDuration,
+        ZonedDateTime startedAt,
+        ZonedDateTime finishedAt,
+        boolean isShowStock,
+        // command meta info
+        ZonedDateTime requestTime
 ) {
     private static final String ERROR_MAX_PURCHASE_LIMIT = "최대 구매 수량 제한은 0보다 커야 합니다. 최대 구매 수량 제한: %d";
     private static final String ERROR_VARIATION_DURATION = "변동 시간 단위는 0보다 커야 합니다. 변동 시간: %s";
@@ -64,7 +64,7 @@ public record UpdateAuctionCommand(
     private void validateMaximumPurchaseLimitCount(int maximumPurchaseLimitCount) {
         if (maximumPurchaseLimitCount <= 0) {
             throw new BadRequestException(String.format(ERROR_MAX_PURCHASE_LIMIT, maximumPurchaseLimitCount),
-                ErrorCode.A003);
+                    ErrorCode.A003);
         }
     }
 

--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/service/AuctionService.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/service/AuctionService.java
@@ -82,13 +82,13 @@ public class AuctionService {
     public void changeOption(UpdateAuctionCommand command) {
         // 검증
         Auction auction = auctionRepository.findById(command.auctionId())
-            .orElseThrow(() -> new NotFoundException("경매(Auction)를 찾을 수 없습니다. AuctionId: " + command.auctionId(),
-                ErrorCode.A011));
+                .orElseThrow(() -> new NotFoundException("경매(Auction)를 찾을 수 없습니다. AuctionId: " + command.auctionId(),
+                        ErrorCode.A011));
 
         if (auction.getStatus() != AuctionStatus.WAITING) {
             throw new BadRequestException(
-                "시작 전인 경매만 변경할 수 있습니다. 변경요청시간: " + command.requestTime() + ", 경매시작시간: " + auction.getStartedAt(),
-                ErrorCode.A012);
+                    "시작 전인 경매만 변경할 수 있습니다. 변경요청시간: " + command.requestTime() + ", 경매시작시간: " + auction.getStartedAt(),
+                    ErrorCode.A012);
         }
 
         // 변경 TODO

--- a/src/main/java/com/wootecam/luckyvickyauction/core/member/domain/Member.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/member/domain/Member.java
@@ -15,6 +15,7 @@ public class Member {
     @Builder
     public Member(String signInId, String password, Role role, Point point) {
         this.signInId = signInId;
+        this.password = password;
         this.role = role;
         this.point = point;
     }

--- a/src/main/java/com/wootecam/luckyvickyauction/core/member/domain/Member.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/member/domain/Member.java
@@ -8,27 +8,28 @@ public class Member {
 
     private Long id;
     private String signInId;
+    private String password;
     private Role role;
     protected Point point;
 
     @Builder
-    public Member(final String signInId, final Role role, final Point point) {
+    public Member(String signInId, String password, Role role, Point point) {
         this.signInId = signInId;
         this.role = role;
         this.point = point;
     }
 
-    public static Member createMemberWithRole(final String signInId, final String userRole) {
+    public static Member createMemberWithRole(String signInId, String password, String userRole) {
         Role role = Role.find(userRole);
 
-        return new Member(signInId, role, new Point(0L));
+        return new Member(signInId, password, role, new Point(0L));
     }
 
-    public void usePoint(final long price) {
+    public void usePoint(long price) {
         point.minus(price);
     }
 
-    public void chargePoint(final long price) {
+    public void chargePoint(long price) {
         point.plus(price);
     }
 

--- a/src/main/java/com/wootecam/luckyvickyauction/core/member/dto/SignUpInfo.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/member/dto/SignUpInfo.java
@@ -1,0 +1,26 @@
+package com.wootecam.luckyvickyauction.core.member.dto;
+
+import com.wootecam.luckyvickyauction.global.exception.BadRequestException;
+import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
+import java.util.Objects;
+
+public record SignUpInfo(
+        String signUpId,
+        String password,
+        String userRole
+) {
+
+    private static final String ERROR_NULL_VALUE = "%s는 Null일 수 없습니다.";
+
+    public SignUpInfo {
+        validateNotNull(signUpId, "회원가입 ID");
+        validateNotNull(password, "회원가입 패스워드");
+        validateNotNull(userRole, "사용자 역할");
+    }
+
+    private void validateNotNull(Object value, String fieldName) {
+        if (Objects.isNull(value)) {
+            throw new BadRequestException(String.format(ERROR_NULL_VALUE, fieldName), ErrorCode.A007);
+        }
+    }
+}

--- a/src/main/java/com/wootecam/luckyvickyauction/core/member/service/MemberService.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.wootecam.luckyvickyauction.core.member.service;
 
 import com.wootecam.luckyvickyauction.core.member.domain.Member;
 import com.wootecam.luckyvickyauction.core.member.domain.MemberRepository;
+import com.wootecam.luckyvickyauction.core.member.dto.SignUpInfo;
 import com.wootecam.luckyvickyauction.global.exception.BadRequestException;
 import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
 import jakarta.servlet.http.HttpSession;
@@ -12,20 +13,17 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    /**
-     * 로그인(회원가입)을 동시에 처리한다.
-     *
-     * @param signInId 로그인(회원가입)할 아이디
-     * @param userRole 사용자의 역할(구매자, 판매자)
-     */
-    public void signIn(String signInId, String userRole, HttpSession session) {
-        if (memberRepository.isExist(signInId)) {
-            throw new BadRequestException("이미 존재하는 아이디입니다. input=" + signInId, ErrorCode.M000);
+    public void signUp(SignUpInfo signUpInfo) {
+        if (memberRepository.isExist(signUpInfo.signUpId())) {
+            throw new BadRequestException("이미 존재하는 아이디입니다. input=" + signUpInfo.signUpId(), ErrorCode.M000);
         }
-        Member member = Member.createMemberWithRole(signInId, userRole);
-        Member savedMember = memberRepository.save(member);
+        Member member = Member.createMemberWithRole(
+                signUpInfo.signUpId(),
+                signUpInfo.password(),
+                signUpInfo.userRole()
+        );
 
-        session.setAttribute("signInUser", savedMember);
+        memberRepository.save(member);
     }
 
     public void signOut(HttpSession session) {

--- a/src/test/java/com/wootecam/luckyvickyauction/core/member/domain/MemberTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/member/domain/MemberTest.java
@@ -2,6 +2,7 @@ package com.wootecam.luckyvickyauction.core.member.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wootecam.luckyvickyauction.global.exception.BadRequestException;
 import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
@@ -10,9 +11,23 @@ import org.junit.jupiter.api.Test;
 class MemberTest {
 
     @Test
+    void 회원을_생성할_수_있다() {
+        // when
+        Member member = new Member("testId", "password", Role.BUYER, new Point(100));
+
+        // then
+        assertAll(
+                () -> assertThat(member.getSignInId()).isEqualTo("testId"),
+                () -> assertThat(member.getPassword()).isEqualTo("password"),
+                () -> assertThat(member.getRole()).isEqualTo(Role.BUYER),
+                () -> assertThat(member.getPoint()).isEqualTo(new Point(100))
+        );
+    }
+
+    @Test
     void 포인트를_사용할_수_있다() {
         // given
-        Member buyer = new Member("testId", Role.BUYER, new Point(100));
+        Member buyer = new Member("testId", "password", Role.BUYER, new Point(100));
         long price = 10L;
         long quantity = 10L;
 
@@ -26,7 +41,7 @@ class MemberTest {
     @Test
     void 보유한_포인트보다_많은_포인트를_사용하려하면_예외가_발생한다() {
         // given
-        Member buyer = new Member("testId", Role.BUYER, new Point(100));
+        Member buyer = new Member("testId", "password", Role.BUYER, new Point(100));
 
         // expect
         assertThatThrownBy(() -> buyer.usePoint(10 * 11))
@@ -38,7 +53,7 @@ class MemberTest {
     @Test
     void 포인트를_충전할_수_있다() {
         // given
-        Member seller = new Member("testID", Role.SELLER, new Point(0));
+        Member seller = new Member("testID", "password", Role.SELLER, new Point(0));
 
         // when
         seller.chargePoint(100);

--- a/src/test/java/com/wootecam/luckyvickyauction/core/member/service/MemberServiceTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/member/service/MemberServiceTest.java
@@ -1,5 +1,34 @@
 package com.wootecam.luckyvickyauction.core.member.service;
 
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 // TODO: Spring 의존성, DB 뭍으면 테스트 작성하기
 class MemberServiceTest {
+
+    @Nested
+    class signUp_메소드는 {
+
+        @Nested
+        class 만약_이미_존재하는_아이디로_회원가입을_시도하면 {
+
+            @Test
+            void 예외가_발생한다() {
+                // given
+                // when
+                // then
+            }
+        }
+
+        @Nested
+        class 정상적인_회원가입_요청이_입력되면 {
+
+            @Test
+            void 회원가입이_완료된다() {
+                // given
+                // when
+                // then
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 📄 Summary
- MemberService#signUp 메서드 수정
   - 기존에 `HttpSession` 객체를 파라미터로 받은 코드를 테스트에 용이하도록 변경하였습니다.
   - `HttpSession` 대신 `SignInfo` dto를 이용해서 회원가입 메서드에 필요한 파라미터를 입력 받도록 변경하였습니다.
- 코드 컨벤션을 지키기 위해서 인덴트 정렬을 했습니다.

close #51 