### PR TITLE
refactor: 판매자가 경매 상세 조회시 다음 정보를 조회할 수 있다.

### DIFF
--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/dto/SellerAuctionInfo.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/dto/SellerAuctionInfo.java
@@ -13,11 +13,11 @@ import lombok.Builder;
 @Builder
 public record SellerAuctionInfo(
         Long auctionId,
-        Long sellerId,
         String productName,
         long originPrice,
         long currentPrice,
-        long stock,
+        long originStock,
+        long currentStock,
         long maximumPurchaseLimitCount,
         PricePolicy pricePolicy,
         Duration variationDuration,
@@ -29,14 +29,14 @@ public record SellerAuctionInfo(
     public static final String ERROR_PRODUCT_NAME = "상품 이름은 비어있을 수 없습니다.";
     public static final String ERROR_ORIGIN_PRICE = "상품 원가는 0보다 커야 합니다. 상품 원가: %d";
     public static final String ERROR_CURRENT_PRICE = "현재 가격은 0보다 커야 합니다. 현재 가격: %d";
-    public static final String ERROR_STOCK = "재고는 0보다 작을 수 없습니다. 재고: %d";
+    public static final String ERROR_ORIGIN_STOCK = "원래 재고는 0 이하일 수 없습니다. 재고: %d";
+    public static final String ERROR_CURRENT_STOCK = "현재 재고는 0보다 작을 수 없습니다. 재고: %d";
     public static final String ERROR_MAXIMUM_PURCHASE_LIMIT_COUNT = "최대 구매 수량 제한은 0보다 커야 합니다. 최대 구매 수량 제한: %d";
     public static final String ERROR_VARIATION_DURATION = "변동 시간 단위는 0보다 커야 합니다. 변동 시간: %s";
     public static final String ERROR_NULL_VALUE = "%s는 Null일 수 없습니다.";
 
     public SellerAuctionInfo {
         validateNotNull(auctionId, "경매 ID");
-        validateNotNull(sellerId, "판매자 ID");
         validateNotNull(productName, "상품 이름");
         validateNotNull(pricePolicy, "경매 유형");
         validateNotNull(variationDuration, "가격 변동 주기");
@@ -46,7 +46,8 @@ public record SellerAuctionInfo(
         validateProductName(productName);
         validateOriginPrice(originPrice);
         validateCurrentPrice(currentPrice);
-        validateStock(stock);
+        validateOriginStock(originStock);
+        validateCurrentStock(currentStock);
         validateMaximumPurchaseLimitCount(maximumPurchaseLimitCount);
         validateVariationDuration(variationDuration);
     }
@@ -69,9 +70,15 @@ public record SellerAuctionInfo(
         }
     }
 
-    private void validateStock(long stock) {
-        if (stock < 0) {
-            throw new BadRequestException(String.format(ERROR_STOCK, stock), ErrorCode.A000);
+    private void validateOriginStock(long originStock) {
+        if (originStock <= 0) {
+            throw new BadRequestException(String.format(ERROR_ORIGIN_STOCK, originStock), ErrorCode.A000);
+        }
+    }
+
+    private void validateCurrentStock(long currentStock) {
+        if (currentStock < 0) {
+            throw new BadRequestException(String.format(ERROR_CURRENT_STOCK, currentStock), ErrorCode.A000);
         }
     }
 

--- a/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
@@ -82,11 +82,11 @@ public final class Mapper {
     public static SellerAuctionInfo convertToSellerAuctionInfo(Auction auction) {
         return SellerAuctionInfo.builder()
                 .auctionId(auction.getId())
-                .sellerId(auction.getSellerId())
                 .productName(auction.getProductName())
                 .originPrice(auction.getOriginPrice())
                 .currentPrice(auction.getCurrentPrice())
-                .stock(auction.getCurrentStock())
+                .originStock(auction.getOriginStock())
+                .currentStock(auction.getCurrentStock())
                 .maximumPurchaseLimitCount(auction.getMaximumPurchaseLimitCount())
                 .pricePolicy(auction.getPricePolicy())
                 .variationDuration(auction.getVariationDuration())

--- a/src/test/java/com/wootecam/luckyvickyauction/core/auction/dto/SellerAuctionInfoTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/auction/dto/SellerAuctionInfoTest.java
@@ -20,19 +20,22 @@ public class SellerAuctionInfoTest {
     static Stream<Arguments> auctionInfoDtoArguments() {
         return Stream.of(
                 Arguments.of("상품 이름은 비어있을 수 없습니다.",
-                        ErrorCode.A001, 1L, 1L, "", 10000, 10000, 10, 10, Duration.ofMinutes(1L), ZonedDateTime.now(),
+                        ErrorCode.A001, 1L, "", 10000, 10000, 10, 10, 10, Duration.ofMinutes(1L), ZonedDateTime.now(),
                         ZonedDateTime.now(), true),
                 Arguments.of("상품 원가는 0보다 커야 합니다. 상품 원가: 0",
-                        ErrorCode.A002, 1L, 1L, "상품이름", 0, 10000, 10, 10, Duration.ofMinutes(1L), ZonedDateTime.now(),
+                        ErrorCode.A002, 1L, "상품이름", 0, 10000, 10, 10, 10, Duration.ofMinutes(1L), ZonedDateTime.now(),
                         ZonedDateTime.now(), true),
                 Arguments.of("현재 가격은 0보다 커야 합니다. 현재 가격: 0",
-                        ErrorCode.A013, 1L, 1L, "상품이름", 10000, 0, 10, 10, Duration.ofMinutes(1L), ZonedDateTime.now(),
+                        ErrorCode.A013, 1L, "상품이름", 10000, 0, 10, 10, 10, Duration.ofMinutes(1L), ZonedDateTime.now(),
                         ZonedDateTime.now(), true),
-                Arguments.of("재고는 0보다 작을 수 없습니다. 재고: -1",
-                        ErrorCode.A000, 1L, 1L, "상품이름", 10000, 10000, -1, 10, Duration.ofMinutes(1L),
+                Arguments.of("원래 재고는 0 이하일 수 없습니다. 재고: 0",
+                        ErrorCode.A000, 1L, "상품이름", 10000, 10000, 0, 10, 10, Duration.ofMinutes(1L),
+                        ZonedDateTime.now(), ZonedDateTime.now(), true),
+                Arguments.of("현재 재고는 0보다 작을 수 없습니다. 재고: -1",
+                        ErrorCode.A000, 1L, "상품이름", 10000, 10000, 10, -1, 10, Duration.ofMinutes(1L),
                         ZonedDateTime.now(), ZonedDateTime.now(), true),
                 Arguments.of("최대 구매 수량 제한은 0보다 커야 합니다. 최대 구매 수량 제한: 0",
-                        ErrorCode.A003, 1L, 1L, "상품이름", 10000, 10000, 10, 0, Duration.ofMinutes(1L),
+                        ErrorCode.A003, 1L, "상품이름", 10000, 10000, 10, 10, 0, Duration.ofMinutes(1L),
                         ZonedDateTime.now(), ZonedDateTime.now(), true)
         );
     }
@@ -56,17 +59,17 @@ public class SellerAuctionInfoTest {
         ZonedDateTime finishedAt = ZonedDateTime.now();
 
         // when
-        SellerAuctionInfo sellerAuctionInfo = new SellerAuctionInfo(auctionId, sellerId, productName, originPrice,
-                currentPrice, stock,
+        SellerAuctionInfo sellerAuctionInfo = new SellerAuctionInfo(auctionId, productName, originPrice,
+                currentPrice, stock, stock,
                 maximumPurchaseLimitCount, pricePolicy, varitationDuration, startedAt, finishedAt, true);
 
         // then
         assertAll(
-                () -> assertThat(sellerAuctionInfo.sellerId()).isEqualTo(sellerId),
                 () -> assertThat(sellerAuctionInfo.productName()).isEqualTo(productName),
                 () -> assertThat(sellerAuctionInfo.originPrice()).isEqualTo(originPrice),
                 () -> assertThat(sellerAuctionInfo.currentPrice()).isEqualTo(currentPrice),
-                () -> assertThat(sellerAuctionInfo.stock()).isEqualTo(stock),
+                () -> assertThat(sellerAuctionInfo.originStock()).isEqualTo(stock),
+                () -> assertThat(sellerAuctionInfo.currentStock()).isEqualTo(stock),
                 () -> assertThat(sellerAuctionInfo.maximumPurchaseLimitCount()).isEqualTo(maximumPurchaseLimitCount),
                 () -> assertThat(sellerAuctionInfo.pricePolicy()).isEqualTo(pricePolicy),
                 () -> assertThat(sellerAuctionInfo.variationDuration()).isEqualTo(varitationDuration),
@@ -82,11 +85,11 @@ public class SellerAuctionInfoTest {
             String expectedMessage,
             ErrorCode expectedErrorCode,
             Long auctionId,
-            Long sellerId,
             String productName,
             long originPrice,
             long currentPrice,
-            long stock,
+            long originStock,
+            long currentStock,
             int maximumPurchaseLimitCount,
             Duration variationDuration,
             ZonedDateTime startedAt,
@@ -96,11 +99,11 @@ public class SellerAuctionInfoTest {
         // expect
         assertThatThrownBy(() -> SellerAuctionInfo.builder()
                 .auctionId(auctionId)
-                .sellerId(sellerId)
                 .productName(productName)
                 .originPrice(originPrice)
                 .currentPrice(currentPrice)
-                .stock(stock)
+                .originStock(originStock)
+                .currentStock(currentStock)
                 .maximumPurchaseLimitCount(maximumPurchaseLimitCount)
                 .pricePolicy(PricePolicy.createConstantPricePolicy(1000))
                 .variationDuration(variationDuration)


### PR DESCRIPTION
## 📄 Summary

- 기존에 작성되어 있던 SellerAuctionInfo를 요구사항에 맞게 필드를 변경했습니다
    - SellerId  제거 (판매자 자신의 정보이기 때문에 불필요하여 삭제했습니다)
    - Stock -> OriginStock, CurrentStock으로 분리
- 이를 확인하는 테스트도 추가했습니다

## 🙋🏻 More

처음에 SellerAuctionInfo 부분을 짤 때 제대로 설계하고 짜야 했는데 누구죠? (접니다..)


close #48