### PR TITLE
feat: 구매자는 거래 목록을 최대 100개까지 한번에 조회할 수 있다

### DIFF
--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/domain/BidHistoryRepository.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/domain/BidHistoryRepository.java
@@ -1,6 +1,6 @@
 package com.wootecam.luckyvickyauction.core.payment.domain;
 
-import com.wootecam.luckyvickyauction.core.payment.dto.ReceiptSelectCondition;
+import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSearchCondition;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,5 +10,5 @@ public interface BidHistoryRepository {
 
     Optional<BidHistory> findById(long bidHistoryId);
 
-    List<BidHistory> findAllBy(ReceiptSelectCondition condition);
+    List<BidHistory> findAllBy(BuyerReceiptSearchCondition condition);
 }

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSearchCondition.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSearchCondition.java
@@ -7,11 +7,11 @@ import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
  * 거래 내역 목록 조회시 적용할 수 있는 조건을 나타내는 dto 입니다.
  * @param size 조회할 거래 내역의 개수 (default: 10) (Min: 1, Max: 100)
  */
-public record ReceiptSelectCondition(
+public record BuyerReceiptSearchCondition(
         int size
 ) {
 
-    public ReceiptSelectCondition {
+    public BuyerReceiptSearchCondition {
         pageSizeShouldBeBetweenOneAndHundred();
     }
 

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/ReceiptSelectCondition.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/ReceiptSelectCondition.java
@@ -1,13 +1,23 @@
 package com.wootecam.luckyvickyauction.core.payment.dto;
 
-import lombok.Builder;
+import com.wootecam.luckyvickyauction.global.exception.BadRequestException;
+import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
 
 /**
  * 거래 내역 목록 조회시 적용할 수 있는 조건을 나타내는 dto 입니다.
+ * @param size 조회할 거래 내역의 개수 (default: 10) (Min: 1, Max: 100)
  */
-public class ReceiptSelectCondition {
+public record ReceiptSelectCondition(
+        int size
+) {
 
-    @Builder
-    private ReceiptSelectCondition() {
+    public ReceiptSelectCondition {
+        pageSizeShouldBeBetweenOneAndHundred();
+    }
+
+    private void pageSizeShouldBeBetweenOneAndHundred() {
+        if (size < 1 || size > 100) {
+            throw new BadRequestException("size는 1 이상 100 이하의 값이어야 합니다.", ErrorCode.G001);
+        }
     }
 }

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/service/BidHistoryService.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/service/BidHistoryService.java
@@ -33,11 +33,7 @@ public class BidHistoryService {
         return Mapper.convertToBidHistoryInfo(bidHistory);
     }
 
-    public List<BuyerReceiptSimpleInfo> getBuyerReceiptSimpleInfos(Member member) {
-
-        ReceiptSelectCondition condition = ReceiptSelectCondition.builder()
-                .build();
-
+    public List<BuyerReceiptSimpleInfo> getBuyerReceiptSimpleInfos(ReceiptSelectCondition condition) {
         List<BidHistory> bidHistories = bidHistoryRepository.findAllBy(condition);
         return bidHistories.stream()
                 .map(Mapper::convertToBuyerReceiptSimpleInfo)

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/service/BidHistoryService.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/service/BidHistoryService.java
@@ -4,8 +4,8 @@ import com.wootecam.luckyvickyauction.core.member.domain.Member;
 import com.wootecam.luckyvickyauction.core.payment.domain.BidHistory;
 import com.wootecam.luckyvickyauction.core.payment.domain.BidHistoryRepository;
 import com.wootecam.luckyvickyauction.core.payment.dto.BidHistoryInfo;
+import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSearchCondition;
 import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSimpleInfo;
-import com.wootecam.luckyvickyauction.core.payment.dto.ReceiptSelectCondition;
 import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
 import com.wootecam.luckyvickyauction.global.exception.NotFoundException;
 import com.wootecam.luckyvickyauction.global.exception.UnauthorizedException;
@@ -33,7 +33,7 @@ public class BidHistoryService {
         return Mapper.convertToBidHistoryInfo(bidHistory);
     }
 
-    public List<BuyerReceiptSimpleInfo> getBuyerReceiptSimpleInfos(ReceiptSelectCondition condition) {
+    public List<BuyerReceiptSimpleInfo> getBuyerReceiptSimpleInfos(BuyerReceiptSearchCondition condition) {
         List<BidHistory> bidHistories = bidHistoryRepository.findAllBy(condition);
         return bidHistories.stream()
                 .map(Mapper::convertToBuyerReceiptSimpleInfo)

--- a/src/main/java/com/wootecam/luckyvickyauction/global/exception/ErrorCode.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/exception/ErrorCode.java
@@ -56,7 +56,8 @@ public enum ErrorCode {
     P006("포인트 충전 시, 충전 후 포인트가 Long 최대값을 초과할 경우 예외가 발생합니다."),
 
     // Global 예외
-    G000("DTO 생성 시, 필드의 값이 NULL인 경우 예외가 발생합니다.");
+    G000("DTO 생성 시, 필드의 값이 NULL인 경우 예외가 발생합니다."),
+    G001("목록 조회시, 과도한 데이터를 조회할 수 없습니다.");
 
     private final String description;
 

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSelectConditionTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSelectConditionTest.java
@@ -7,7 +7,7 @@ import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class ReceiptSelectConditionTest {
+class BuyerReceiptSelectConditionTest {
 
     /**
      * @see <a href="https://github.com/woowa-techcamp-2024/Team7-ELEVEN/issues/158">[FEATURE] 구매자는 거래 목록을 최대 100개까지 한번에

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/dto/ReceiptSelectConditionTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/dto/ReceiptSelectConditionTest.java
@@ -1,0 +1,24 @@
+package com.wootecam.luckyvickyauction.core.payment.dto;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wootecam.luckyvickyauction.global.exception.BadRequestException;
+import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ReceiptSelectConditionTest {
+
+    /**
+     * @see <a href="https://github.com/woowa-techcamp-2024/Team7-ELEVEN/issues/158">[FEATURE] 구매자는 거래 목록을 최대 100개까지 한번에
+     * 조회할 수 있다.</a>
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {0, 101})
+    public void size가_1미만이거나_100초과인_경우_예외가_발생한다(int size) {
+
+        assertThatThrownBy(() -> new ReceiptSelectCondition(size))
+                .isInstanceOf(BadRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.G001);
+    }
+}

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/dto/ReceiptSelectConditionTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/dto/ReceiptSelectConditionTest.java
@@ -17,7 +17,7 @@ class ReceiptSelectConditionTest {
     @ValueSource(ints = {0, 101})
     public void size가_1미만이거나_100초과인_경우_예외가_발생한다(int size) {
 
-        assertThatThrownBy(() -> new ReceiptSelectCondition(size))
+        assertThatThrownBy(() -> new BuyerReceiptSearchCondition(size))
                 .isInstanceOf(BadRequestException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.G001);
     }

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/repository/FakeBidHistoryRepository.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/repository/FakeBidHistoryRepository.java
@@ -2,7 +2,7 @@ package com.wootecam.luckyvickyauction.core.payment.repository;
 
 import com.wootecam.luckyvickyauction.core.payment.domain.BidHistory;
 import com.wootecam.luckyvickyauction.core.payment.domain.BidHistoryRepository;
-import com.wootecam.luckyvickyauction.core.payment.dto.ReceiptSelectCondition;
+import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSearchCondition;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +37,7 @@ public class FakeBidHistoryRepository implements BidHistoryRepository {
 
     // TODO: [ReceiptSelectCondition 조건 이후 변경 사항] [writeAt: 2024/08/15/16:03] [writeBy: yudonggeun]
     @Override
-    public List<BidHistory> findAllBy(ReceiptSelectCondition condition) {
+    public List<BidHistory> findAllBy(BuyerReceiptSearchCondition condition) {
         return bidHistories.values().stream()
                 .filter(history -> true)
                 .toList();


### PR DESCRIPTION
## 📄 Summary

- `ReceiptSelectCondition` > `BuyerReceiptSearchCondition` 네이밍 변경
- `ReceiptSelectCondition` 제약구현
    - `size` : 조회하는 목록의 크기는 최대 100개까지 조회할 수 있습니다 
- `ReceiptSelectCondition` 제약 테스트 작성

## 🙋🏻 More

>


close #158