### PR TITLE
feat: 구매자는 자신의 거래 목록만을 조회할 수 있다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // query dsl library add
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // spring-rest-docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:3.0.1'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'io.rest-assured:spring-mock-mvc:5.3.2'
+
+    // h2
+    testCompileOnly 'com.h2database:h2:2.2.220'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/domain/BidHistory.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/domain/BidHistory.java
@@ -16,8 +16,8 @@ public class BidHistory {
     private long quantity;
     private BidStatus bidStatus;
     private long auctionId;
-    private Member seller;
-    private Member buyer;
+    private long sellerId;
+    private long buyerId;
     private ZonedDateTime createdAt;
     private ZonedDateTime updatedAt;
 
@@ -31,8 +31,8 @@ public class BidHistory {
             final long quantity,
             final BidStatus bidStatus,
             final long auctionId,
-            final Member seller,
-            final Member buyer,
+            final long sellerId,
+            final long buyerId,
             final ZonedDateTime createdAt,
             final ZonedDateTime updatedAt) {
         this.id = id;
@@ -41,8 +41,8 @@ public class BidHistory {
         this.quantity = quantity;
         this.bidStatus = bidStatus;
         this.auctionId = auctionId;
-        this.seller = seller;
-        this.buyer = buyer;
+        this.sellerId = sellerId;
+        this.buyerId = buyerId;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -68,8 +68,9 @@ public class BidHistory {
             return false;
         }
 
-        String signInId = member.getSignInId();
-        return seller.isSameMember(signInId) || buyer.isSameMember(signInId);
+        Long requestUserId = member.getId();
+
+        return sellerId == requestUserId || buyerId == requestUserId;
     }
 
 }

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/BidHistoryInfo.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/BidHistoryInfo.java
@@ -1,9 +1,6 @@
 package com.wootecam.luckyvickyauction.core.payment.dto;
 
-import com.wootecam.luckyvickyauction.core.member.domain.Member;
 import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
-import com.wootecam.luckyvickyauction.global.exception.BadRequestException;
-import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
 import java.time.ZonedDateTime;
 import lombok.Builder;
 
@@ -15,51 +12,52 @@ public record BidHistoryInfo(
         long quantity,
         BidStatus bidStatus,
         long auctionId,
-        Member seller,
-        Member buyer,
+        long sellerId,
+        long buyerId,
         ZonedDateTime createdAt,
         ZonedDateTime updatedAt
 ) {
 
-    public static final String ERROR_PRODUCT_NAME = "상품 이름은 비어있을 수 없습니다.";
-    public static final String ERROR_PRICE = "거래 가격은 0보다 커야 합니다. 입찰 가격: %d";
-    public static final String ERROR_QUANTITY = "수량은 0보다 커야 합니다. 수량: %d";
-    public static final String ERROR_NULL_VALUE = "%s는 Null일 수 없습니다.";
-
-    public BidHistoryInfo {
-        validateNotNull(productName, "상품 이름");
-        validateNotNull(bidStatus, "입찰 상태");
-        validateNotNull(seller, "판매자 정보");
-        validateNotNull(buyer, "구매자 정보");
-        validateNotNull(createdAt, "거래 일자");
-        validateNotNull(updatedAt, "변경 일자");
-
-        validateProductName(productName);
-        validatePrice(price);
-        validateQuantity(quantity);
-    }
-
-    private static void validateQuantity(long quantity) {
-        if (quantity <= 0) {
-            throw new BadRequestException(String.format(ERROR_QUANTITY, quantity), ErrorCode.B004);
-        }
-    }
-
-    private void validateProductName(String productName) {
-        if (productName == null || productName.isBlank()) {
-            throw new BadRequestException(ERROR_PRODUCT_NAME, ErrorCode.B002);
-        }
-    }
-
-    private void validatePrice(long price) {
-        if (price <= 0) {
-            throw new BadRequestException(String.format(ERROR_PRICE, price), ErrorCode.B003);
-        }
-    }
-
-    private void validateNotNull(Object value, String fieldName) {
-        if (value == null) {
-            throw new BadRequestException(String.format(ERROR_NULL_VALUE, fieldName), ErrorCode.G000);
-        }
-    }
+    // TODO [응답용 Dto에 가까워서 검증 로직을 제거하였습니다. 주석의 내용을 컨트롤러에서 구현해야하기 때문에 주석으로 표시합니다.] [2021/08/15/14:18] yudonggeun
+//    public static final String ERROR_PRODUCT_NAME = "상품 이름은 비어있을 수 없습니다.";
+//    public static final String ERROR_PRICE = "거래 가격은 0보다 커야 합니다. 입찰 가격: %d";
+//    public static final String ERROR_QUANTITY = "수량은 0보다 커야 합니다. 수량: %d";
+//    public static final String ERROR_NULL_VALUE = "%s는 Null일 수 없습니다.";
+//
+//    public BidHistoryInfo {
+//        validateNotNull(productName, "상품 이름");
+//        validateNotNull(bidStatus, "입찰 상태");
+//        validateNotNull(sellerId, "판매자 정보");
+//        validateNotNull(buyerId, "구매자 정보");
+//        validateNotNull(createdAt, "거래 일자");
+//        validateNotNull(updatedAt, "변경 일자");
+//
+//        validateProductName(productName);
+//        validatePrice(price);
+//        validateQuantity(quantity);
+//    }
+//
+//    private static void validateQuantity(long quantity) {
+//        if (quantity <= 0) {
+//            throw new BadRequestException(String.format(ERROR_QUANTITY, quantity), ErrorCode.B004);
+//        }
+//    }
+//
+//    private void validateProductName(String productName) {
+//        if (productName == null || productName.isBlank()) {
+//            throw new BadRequestException(ERROR_PRODUCT_NAME, ErrorCode.B002);
+//        }
+//    }
+//
+//    private void validatePrice(long price) {
+//        if (price <= 0) {
+//            throw new BadRequestException(String.format(ERROR_PRICE, price), ErrorCode.B003);
+//        }
+//    }
+//
+//    private void validateNotNull(Object value, String fieldName) {
+//        if (value == null) {
+//            throw new BadRequestException(String.format(ERROR_NULL_VALUE, fieldName), ErrorCode.G000);
+//        }
+//    }
 }

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSearchCondition.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSearchCondition.java
@@ -13,10 +13,10 @@ public record BuyerReceiptSearchCondition(
 ) {
 
     public BuyerReceiptSearchCondition {
-        pageSizeShouldBeBetweenOneAndHundred();
+        pageSizeShouldBeBetweenOneAndHundred(size);
     }
 
-    private void pageSizeShouldBeBetweenOneAndHundred() {
+    private void pageSizeShouldBeBetweenOneAndHundred(int size) {
         if (size < 1 || size > 100) {
             throw new BadRequestException("size는 1 이상 100 이하의 값이어야 합니다.", ErrorCode.G001);
         }

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSearchCondition.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSearchCondition.java
@@ -8,6 +8,7 @@ import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
  * @param size 조회할 거래 내역의 개수 (default: 10) (Min: 1, Max: 100)
  */
 public record BuyerReceiptSearchCondition(
+        Long buyerId,
         int size
 ) {
 

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/entity/ReceiptEntity.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/entity/ReceiptEntity.java
@@ -1,14 +1,44 @@
 package com.wootecam.luckyvickyauction.core.payment.entity;
 
+import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.ZonedDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "RECEIPT")
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReceiptEntity {
     @Id
     private Long id;
+    private String productName;
+    private long price;
+    private long quantity;
+    private BidStatus bidStatus;
+    private long auctionId;
+    private Long sellerId;
+    private Long buyerId;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+
+    @Builder
+    private ReceiptEntity(Long id, String productName, long price, long quantity, BidStatus bidStatus, long auctionId,
+                          Long sellerId, Long buyerId, ZonedDateTime createdAt, ZonedDateTime updatedAt) {
+        this.id = id;
+        this.productName = productName;
+        this.price = price;
+        this.quantity = quantity;
+        this.bidStatus = bidStatus;
+        this.auctionId = auctionId;
+        this.sellerId = sellerId;
+        this.buyerId = buyerId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
 }

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/entity/ReceiptEntity.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/entity/ReceiptEntity.java
@@ -2,6 +2,8 @@ package com.wootecam.luckyvickyauction.core.payment.entity;
 
 import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.ZonedDateTime;
@@ -16,6 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReceiptEntity {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String productName;
     private long price;

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptCoreRepository.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptCoreRepository.java
@@ -3,6 +3,7 @@ package com.wootecam.luckyvickyauction.core.payment.infra;
 import com.wootecam.luckyvickyauction.core.payment.domain.BidHistory;
 import com.wootecam.luckyvickyauction.core.payment.domain.BidHistoryRepository;
 import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSearchCondition;
+import com.wootecam.luckyvickyauction.global.util.Mapper;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,9 @@ public class ReceiptCoreRepository implements BidHistoryRepository {
 
     @Override
     public List<BidHistory> findAllBy(BuyerReceiptSearchCondition condition) {
-        return List.of();
+
+        return receiptJpaRepository.findAllBy(condition).stream()
+                .map(Mapper::convertToReceipt)
+                .toList();
     }
 }

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptJpaRepository.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptJpaRepository.java
@@ -3,5 +3,5 @@ package com.wootecam.luckyvickyauction.core.payment.infra;
 import com.wootecam.luckyvickyauction.core.payment.entity.ReceiptEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReceiptJpaRepository extends JpaRepository<ReceiptEntity, Long> {
+public interface ReceiptJpaRepository extends JpaRepository<ReceiptEntity, Long>, ReceiptQueryDslRepository {
 }

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepository.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepository.java
@@ -1,0 +1,11 @@
+package com.wootecam.luckyvickyauction.core.payment.infra;
+
+import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSearchCondition;
+import com.wootecam.luckyvickyauction.core.payment.entity.ReceiptEntity;
+import java.util.List;
+
+public interface ReceiptQueryDslRepository {
+
+    List<ReceiptEntity> findAllBy(BuyerReceiptSearchCondition condition);
+
+}

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryImpl.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.wootecam.luckyvickyauction.core.payment.infra;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSearchCondition;
+import com.wootecam.luckyvickyauction.core.payment.entity.ReceiptEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ReceiptQueryDslRepositoryImpl implements ReceiptQueryDslRepository {
+
+    private final JPAQueryFactory factory;
+
+    @Override
+    public List<ReceiptEntity> findAllBy(BuyerReceiptSearchCondition condition) {
+        return null;
+    }
+}

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryImpl.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.wootecam.luckyvickyauction.core.payment.infra;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSearchCondition;
+import com.wootecam.luckyvickyauction.core.payment.entity.QReceiptEntity;
 import com.wootecam.luckyvickyauction.core.payment.entity.ReceiptEntity;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,13 @@ public class ReceiptQueryDslRepositoryImpl implements ReceiptQueryDslRepository 
 
     @Override
     public List<ReceiptEntity> findAllBy(BuyerReceiptSearchCondition condition) {
-        return null;
+        QReceiptEntity receipt = QReceiptEntity.receiptEntity;
+
+        return factory
+                .select(receipt)
+                .from(receipt)
+                .where(receipt.buyerId.eq(condition.buyerId()))
+                .limit(condition.size())
+                .fetch();
     }
 }

--- a/src/main/java/com/wootecam/luckyvickyauction/global/config/JpaConfig.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/config/JpaConfig.java
@@ -1,0 +1,19 @@
+package com.wootecam.luckyvickyauction.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
@@ -9,6 +9,7 @@ import com.wootecam.luckyvickyauction.core.auction.dto.SellerAuctionSimpleInfo;
 import com.wootecam.luckyvickyauction.core.payment.domain.BidHistory;
 import com.wootecam.luckyvickyauction.core.payment.dto.BidHistoryInfo;
 import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSimpleInfo;
+import com.wootecam.luckyvickyauction.core.payment.entity.ReceiptEntity;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -132,5 +133,20 @@ public final class Mapper {
                 auction.getStartedAt(),
                 auction.getFinishedAt()
         );
+    }
+
+    public static BidHistory convertToReceipt(ReceiptEntity receiptEntity) {
+        return BidHistory.builder()
+                .id(receiptEntity.getId())
+                .productName(receiptEntity.getProductName())
+                .price(receiptEntity.getPrice())
+                .quantity(receiptEntity.getQuantity())
+                .bidStatus(receiptEntity.getBidStatus())
+                .auctionId(receiptEntity.getAuctionId())
+                .sellerId(receiptEntity.getSellerId())
+                .buyerId(receiptEntity.getBuyerId())
+                .createdAt(receiptEntity.getCreatedAt())
+                .updatedAt(receiptEntity.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
@@ -45,8 +45,8 @@ public final class Mapper {
                 .quantity(bidHistory.getQuantity())
                 .bidStatus(bidHistory.getBidStatus())
                 .auctionId(bidHistory.getAuctionId())
-                .seller(bidHistory.getSeller())
-                .buyer(bidHistory.getBuyer())
+                .sellerId(bidHistory.getSellerId())
+                .buyerId(bidHistory.getBuyerId())
                 .createdAt(bidHistory.getCreatedAt())
                 .updatedAt(bidHistory.getUpdatedAt())
                 .build();

--- a/src/test/java/com/wootecam/luckyvickyauction/core/auction/service/GetSellerAuctionTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/auction/service/GetSellerAuctionTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wootecam.luckyvickyauction.core.auction.domain.Auction;
 import com.wootecam.luckyvickyauction.core.auction.domain.AuctionRepository;
+import com.wootecam.luckyvickyauction.core.auction.domain.ConstantPricePolicy;
 import com.wootecam.luckyvickyauction.core.auction.dto.SellerAuctionInfo;
 import com.wootecam.luckyvickyauction.core.auction.fixture.AuctionFixture;
 import com.wootecam.luckyvickyauction.core.auction.infra.FakeAuctionRepository;
@@ -14,6 +15,8 @@ import com.wootecam.luckyvickyauction.core.member.dto.SignInInfo;
 import com.wootecam.luckyvickyauction.core.member.fixture.MemberFixture;
 import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
 import com.wootecam.luckyvickyauction.global.exception.UnauthorizedException;
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,7 +42,24 @@ abstract class GetSellerAuctionTest {
         void 판매자의_경매목록을_반환한다() {
             // given
             Member seller = MemberFixture.createSellerWithDefaultPoint();
-            Auction auction = auctionRepository.save(AuctionFixture.createWaitingAuction());
+
+            ZonedDateTime now = ZonedDateTime.now();
+            Auction action = Auction.builder()
+                    .sellerId(seller.getId())
+                    .productName("productName")
+                    .originPrice(10000L)
+                    .currentPrice(10000L)
+                    .originStock(100L)
+                    .currentStock(100L)
+                    .maximumPurchaseLimitCount(10L)
+                    .pricePolicy(new ConstantPricePolicy(1000L))
+                    .variationDuration(Duration.ofMinutes(10L))
+                    .startedAt(now.plusHours(1))
+                    .finishedAt(now.plusHours(2))
+                    .isShowStock(true)
+                    .build();
+
+            Auction auction = auctionRepository.save(action);
 
             SignInInfo signInInfo = new SignInInfo(seller.getId(), seller.getRole());
 

--- a/src/test/java/com/wootecam/luckyvickyauction/core/member/fixture/MemberFixture.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/member/fixture/MemberFixture.java
@@ -11,7 +11,7 @@ public class MemberFixture {
     public static Member createBuyerWithDefaultPoint() {
         return Member.builder()
                 .id(1L)
-                .signInId("buyer")
+                .signInId("buyerId")
                 .password("password00")
                 .role(Role.BUYER)
                 .point(new Point(1000L))
@@ -20,8 +20,8 @@ public class MemberFixture {
 
     public static Member createSellerWithDefaultPoint() {
         return Member.builder()
-                .id(1L)
-                .signInId("seller")
+                .id(2L)
+                .signInId("sellerId")
                 .password("password00")
                 .role(Role.SELLER)
                 .point(new Point(1000L))

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/dto/BidHistoryInfoTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/dto/BidHistoryInfoTest.java
@@ -1,80 +1,15 @@
 package com.wootecam.luckyvickyauction.core.payment.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wootecam.luckyvickyauction.core.member.domain.Member;
-import com.wootecam.luckyvickyauction.core.member.domain.Role;
 import com.wootecam.luckyvickyauction.core.member.fixture.MemberFixture;
 import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
-import com.wootecam.luckyvickyauction.global.exception.BusinessException;
-import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
 import java.time.ZonedDateTime;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 class BidHistoryInfoTest {
-
-    static Stream<Arguments> bidHistoryInfoArguments() {
-        ZonedDateTime now = ZonedDateTime.now();
-
-        return Stream.of(
-                Arguments.of("상품 이름은 비어있을 수 없습니다.", ErrorCode.B002,
-                        1L, "", 10000, 1, BidStatus.BID, 1L,
-                        new Member(1L, "seller", "password00", Role.SELLER, null),
-                        new Member(2L, "buyer", "password00", Role.BUYER, null),
-                        now, now),
-                Arguments.of("상품 이름은 빈 칸일 수 없습니다.", ErrorCode.B002,
-                        1L, "   ", 10000, 1, BidStatus.BID, 1L,
-                        new Member(1L, "seller", "password00", Role.SELLER, null),
-                        new Member(2L, "buyer", "password00", Role.BUYER, null),
-                        now, now),
-                Arguments.of("입찰 가격은 0보다 커야 합니다. 입찰 가격: 0", ErrorCode.B003,
-                        1L, "상품이름", 0, 1, BidStatus.BID, 1L,
-                        new Member(1L, "seller", "password00", Role.SELLER, null),
-                        new Member(2L, "buyer", "password00", Role.BUYER, null),
-                        now, now),
-                Arguments.of("수량은 0보다 커야 합니다. 수량: 0", ErrorCode.B004,
-                        1L, "상품이름", 10000, 0, BidStatus.BID, 1L,
-                        new Member(1L, "seller", "password00", Role.SELLER, null),
-                        new Member(2L, "buyer", "password00", Role.BUYER, null),
-                        now, now),
-                Arguments.of("상품 이름은 Null일 수 없습니다.", ErrorCode.G000,
-                        1L, null, 10000, 1, BidStatus.REFUND, 1L,
-                        new Member(1L, "seller", "password00", Role.SELLER, null),
-                        new Member(2L, "buyer", "password00", Role.BUYER, null),
-                        now, now),
-                Arguments.of("입찰 상태는 Null일 수 없습니다.", ErrorCode.G000,
-                        1L, "상품이름", 10000, 1, null, 1L,
-                        new Member(1L, "seller", "password00", Role.SELLER, null),
-                        new Member(2L, "buyer", "password00", Role.BUYER, null),
-                        now, now),
-                Arguments.of("판매자 정보는 Null일 수 없습니다.", ErrorCode.G000,
-                        1L, "상품이름", 10000, 1, BidStatus.BID, 1L,
-                        null,
-                        new Member(2L, "buyer", "password00", Role.BUYER, null),
-                        now, now),
-                Arguments.of("구매자 정보는 Null일 수 없습니다.", ErrorCode.G000,
-                        1L, "상품이름", 10000, 1, BidStatus.BID, 1L,
-                        new Member(1L, "seller", "password00", Role.SELLER, null),
-                        null,
-                        now, now),
-                Arguments.of("거래 일자는 Null일 수 없습니다.", ErrorCode.G000,
-                        1L, "상품이름", 10000, 1, BidStatus.BID, 1L,
-                        new Member(1L, "seller", "password00", Role.SELLER, null),
-                        new Member(2L, "buyer", "password00", Role.BUYER, null),
-                        null, now),
-                Arguments.of("변경 일자는 Null일 수 없습니다.", ErrorCode.G000,
-                        1L, "상품이름", 10000, 1, BidStatus.BID, 1L,
-                        new Member(1L, "seller", "password00", Role.SELLER, null),
-                        new Member(2L, "buyer", "password00", Role.BUYER, null),
-                        now, null)
-        );
-    }
 
     @Test
     void 입찰_내역_생성_요청을_정상적으로_처리한다() {
@@ -92,7 +27,7 @@ class BidHistoryInfoTest {
 
         // when
         BidHistoryInfo bidHistoryInfo = new BidHistoryInfo(id, productName, price, quantity, bidStatus, auctionId,
-                seller, buyer, createdAt, updatedAt);
+                seller.getId(), buyer.getId(), createdAt, updatedAt);
 
         // then
         assertAll(
@@ -102,33 +37,8 @@ class BidHistoryInfoTest {
                 () -> assertThat(bidHistoryInfo.quantity()).isEqualTo(quantity),
                 () -> assertThat(bidHistoryInfo.bidStatus()).isEqualTo(bidStatus),
                 () -> assertThat(bidHistoryInfo.auctionId()).isEqualTo(auctionId),
-                () -> assertThat(bidHistoryInfo.seller()).isEqualTo(seller),
-                () -> assertThat(bidHistoryInfo.buyer()).isEqualTo(buyer)
+                () -> assertThat(bidHistoryInfo.sellerId()).isEqualTo(seller.getId()),
+                () -> assertThat(bidHistoryInfo.buyerId()).isEqualTo(buyer.getId())
         );
     }
-
-    @ParameterizedTest(name = "예외: {0}")
-    @MethodSource("bidHistoryInfoArguments")
-    void 입찰_내역_생성_요청이_잘못된_경우_예외가_발생한다(
-            String expectedMessage,
-            ErrorCode errorCode,
-            Long id,
-            String productName,
-            long price,
-            long quantity,
-            BidStatus bidStatus,
-            Long auctionId,
-            Member seller,
-            Member buyer,
-            ZonedDateTime createdAt,
-            ZonedDateTime updatedAt
-    ) {
-        // expect
-        assertThatThrownBy(
-                () -> new BidHistoryInfo(id, productName, price, quantity, bidStatus, auctionId, seller, buyer,
-                        createdAt, updatedAt))
-                .isInstanceOf(BusinessException.class)
-                .satisfies(exception -> assertThat(exception).hasFieldOrPropertyWithValue("errorCode", errorCode));
-    }
-
 }

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSelectConditionTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSelectConditionTest.java
@@ -17,7 +17,7 @@ class BuyerReceiptSelectConditionTest {
     @ValueSource(ints = {0, 101})
     public void size가_1미만이거나_100초과인_경우_예외가_발생한다(int size) {
 
-        assertThatThrownBy(() -> new BuyerReceiptSearchCondition(size))
+        assertThatThrownBy(() -> new BuyerReceiptSearchCondition(1L, size))
                 .isInstanceOf(BadRequestException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.G001);
     }

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/FakeBidHistoryRepository.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/FakeBidHistoryRepository.java
@@ -52,8 +52,8 @@ public class FakeBidHistoryRepository implements BidHistoryRepository {
                 .quantity(bidHistory.getQuantity())
                 .bidStatus(bidHistory.getBidStatus())
                 .auctionId(bidHistory.getAuctionId())
-                .seller(bidHistory.getSeller())
-                .buyer(bidHistory.getBuyer())
+                .sellerId(bidHistory.getSellerId())
+                .buyerId(bidHistory.getBuyerId())
                 .createdAt(bidHistory.getCreatedAt())
                 .updatedAt(bidHistory.getUpdatedAt())
                 .build();

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryTest.java
@@ -32,7 +32,7 @@ class ReceiptQueryDslRepositoryTest {
             int size = 100;
             var condition = new BuyerReceiptSearchCondition(buyerId, size);
 
-            for (int i = 0; i < 101; i++) {
+            for (int i = 0; i < size + 1; i++) {
                 repository.save(ReceiptEntity.builder()
                         .productName("상품1")
                         .price(1000)
@@ -57,7 +57,7 @@ class ReceiptQueryDslRepositoryTest {
          * @see <a href="https://github.com/woowa-techcamp-2024/Team7-ELEVEN/issues/157">거래 내역 조회 시 구매자의 거래 내역만 조회</a>
          */
         @Test
-        void 조회한_구매자의_거내_내역만_조회된다() {
+        void 조회한_구매자의_거래_내역만_조회된다() {
 
             // given
             Long buyerId = 1L;

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryTest.java
@@ -5,17 +5,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
 import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSearchCondition;
 import com.wootecam.luckyvickyauction.core.payment.entity.ReceiptEntity;
-import jakarta.transaction.Transactional;
+import com.wootecam.luckyvickyauction.global.config.JpaConfig;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
-@Transactional
-@SpringBootTest
+@Import(JpaConfig.class)
+@DataJpaTest
 class ReceiptQueryDslRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryTest.java
@@ -1,0 +1,68 @@
+package com.wootecam.luckyvickyauction.core.payment.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
+import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSearchCondition;
+import com.wootecam.luckyvickyauction.core.payment.entity.ReceiptEntity;
+import jakarta.transaction.Transactional;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Transactional
+@SpringBootTest
+class ReceiptQueryDslRepositoryTest {
+
+    @Autowired
+    private ReceiptJpaRepository repository;
+
+    @Nested
+    class 구매자_거래_내역_동적_쿼리_실행시 {
+
+        @Test
+        void 조회한_구매자의_거내_내역만_조회된다() {
+
+            // given
+            Long buyerId = 1L;
+            Long otherBuyerId = 2L;
+            int size = 100;
+            var condition = new BuyerReceiptSearchCondition(buyerId, size);
+
+            repository.save(ReceiptEntity.builder()
+                    .productName("상품1")
+                    .price(1000)
+                    .quantity(1)
+                    .bidStatus(BidStatus.BID)
+                    .auctionId(4L)
+                    .buyerId(buyerId)
+                    .sellerId(2L)
+                    .createdAt(ZonedDateTime.now())
+                    .updatedAt(ZonedDateTime.now())
+                    .build());
+
+            repository.save(ReceiptEntity.builder()
+                    .productName("상품1")
+                    .price(1000)
+                    .quantity(1)
+                    .bidStatus(BidStatus.BID)
+                    .auctionId(4L)
+                    .buyerId(otherBuyerId)
+                    .sellerId(2L)
+                    .createdAt(ZonedDateTime.now())
+                    .updatedAt(ZonedDateTime.now())
+                    .build());
+            // when
+            List<ReceiptEntity> receipts = repository.findAllBy(condition);
+
+            // then
+            assertThat(receipts)
+                    .map(ReceiptEntity::getBuyerId)
+                    .allMatch(receiptBuyerId -> Objects.equals(receiptBuyerId, buyerId));
+        }
+    }
+}

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryTest.java
@@ -53,6 +53,9 @@ class ReceiptQueryDslRepositoryTest {
             assertThat(receipts).hasSize(size);
         }
 
+        /**
+         * @see <a href="https://github.com/woowa-techcamp-2024/Team7-ELEVEN/issues/157">거래 내역 조회 시 구매자의 거래 내역만 조회</a>
+         */
         @Test
         void 조회한_구매자의_거내_내역만_조회된다() {
 

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptQueryDslRepositoryTest.java
@@ -25,6 +25,35 @@ class ReceiptQueryDslRepositoryTest {
     class 구매자_거래_내역_동적_쿼리_실행시 {
 
         @Test
+        void 조회_개수만큼_거래_내역을_조회한다() {
+
+            // given
+            Long buyerId = 1L;
+            int size = 100;
+            var condition = new BuyerReceiptSearchCondition(buyerId, size);
+
+            for (int i = 0; i < 101; i++) {
+                repository.save(ReceiptEntity.builder()
+                        .productName("상품1")
+                        .price(1000)
+                        .quantity(1)
+                        .bidStatus(BidStatus.BID)
+                        .auctionId(4L)
+                        .buyerId(buyerId)
+                        .sellerId(2L)
+                        .createdAt(ZonedDateTime.now())
+                        .updatedAt(ZonedDateTime.now())
+                        .build());
+            }
+
+            // when
+            List<ReceiptEntity> receipts = repository.findAllBy(condition);
+
+            // then
+            assertThat(receipts).hasSize(size);
+        }
+
+        @Test
         void 조회한_구매자의_거내_내역만_조회된다() {
 
             // given

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/service/BidHistoryServiceTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/service/BidHistoryServiceTest.java
@@ -62,8 +62,8 @@ class BidHistoryServiceTest {
                     .quantity(1)
                     .bidStatus(BidStatus.BID)
                     .auctionId(1L)
-                    .seller(seller)
-                    .buyer(buyer)
+                    .sellerId(seller.getId())
+                    .buyerId(buyer.getId())
                     .createdAt(now)
                     .updatedAt(now)
                     .build();
@@ -80,8 +80,8 @@ class BidHistoryServiceTest {
                     () -> assertThat(bidHistoryInfo.quantity()).isEqualTo(1),
                     () -> assertThat(bidHistoryInfo.bidStatus()).isEqualTo(BidStatus.BID),
                     () -> assertThat(bidHistoryInfo.auctionId()).isEqualTo(1L),
-                    () -> assertThat(bidHistoryInfo.seller()).isEqualTo(seller),
-                    () -> assertThat(bidHistoryInfo.buyer()).isEqualTo(buyer)
+                    () -> assertThat(bidHistoryInfo.sellerId()).isEqualTo(seller.getId()),
+                    () -> assertThat(bidHistoryInfo.buyerId()).isEqualTo(buyer.getId())
             );
         }
 
@@ -111,8 +111,8 @@ class BidHistoryServiceTest {
 
             BidHistory bidHistory = BidHistory.builder()
                     .id(1L)
-                    .seller(seller)
-                    .buyer(buyer)
+                    .sellerId(seller.getId())
+                    .buyerId(buyer.getId())
                     .build();
             bidHistoryRepository.save(bidHistory);
 
@@ -141,8 +141,8 @@ class BidHistoryServiceTest {
                     .quantity(1)
                     .bidStatus(BidStatus.BID)
                     .auctionId(1L)
-                    .seller(seller1)
-                    .buyer(buyer)
+                    .sellerId(seller1.getId())
+                    .buyerId(buyer.getId())
                     .createdAt(now)
                     .updatedAt(now)
                     .build();

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/service/PaymentServiceTest.java
@@ -120,8 +120,8 @@ class PaymentServiceTest {
                         .price(100L)
                         .quantity(1L)
                         .bidStatus(BidStatus.BID)
-                        .seller(seller)
-                        .buyer(buyer)
+                        .sellerId(seller.getId())
+                        .buyerId(buyer.getId())
                         .createdAt(now)
                         .updatedAt(now)
                         .build();
@@ -132,8 +132,8 @@ class PaymentServiceTest {
 
                 // then
                 BidHistory savedBidHistory = bidHistoryRepository.findById(1L).get();
-                Member savedBuyer = savedBidHistory.getBuyer();
-                Member savedSeller = savedBidHistory.getSeller();
+                Member savedBuyer = memberRepository.findById(savedBidHistory.getBuyerId()).get();
+                Member savedSeller = memberRepository.findById(savedBidHistory.getSellerId()).get();
                 Auction savedAuction = auctionRepository.findById(savedBidHistory.getAuctionId()).get();
                 assertAll(
                         () -> assertThat(savedBidHistory.getBidStatus()).isEqualTo(BidStatus.REFUND),
@@ -167,8 +167,8 @@ class PaymentServiceTest {
                         .price(100L)
                         .quantity(1L)
                         .bidStatus(BidStatus.BID)
-                        .seller(seller)
-                        .buyer(buyer)
+                        .sellerId(seller.getId())
+                        .buyerId(buyer.getId())
                         .createdAt(now)
                         .updatedAt(now)
                         .build();
@@ -230,8 +230,8 @@ class PaymentServiceTest {
                         .price(100L)
                         .quantity(1L)
                         .bidStatus(BidStatus.REFUND)
-                        .seller(seller)
-                        .buyer(buyer)
+                        .sellerId(seller.getId())
+                        .buyerId(buyer.getId())
                         .createdAt(now)
                         .updatedAt(now)
                         .build();
@@ -269,8 +269,8 @@ class PaymentServiceTest {
                         .price(100L)
                         .quantity(1L)
                         .bidStatus(BidStatus.BID)
-                        .seller(seller)
-                        .buyer(buyer)
+                        .sellerId(seller.getId())
+                        .buyerId(buyer.getId())
                         .createdAt(now)
                         .updatedAt(now)
                         .build();

--- a/src/test/java/com/wootecam/luckyvickyauction/global/util/MapperTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/global/util/MapperTest.java
@@ -30,8 +30,8 @@ class MapperTest {
                 .productName("상품 이름")
                 .price(1000L)
                 .quantity(1L)
-                .buyer(buyer)
-                .seller(seller)
+                .sellerId(seller.getId())
+                .buyerId(buyer.getId())
                 .build();
 
         // when

--- a/src/test/java/com/wootecam/luckyvickyauction/global/util/MapperTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/global/util/MapperTest.java
@@ -11,9 +11,12 @@ import com.wootecam.luckyvickyauction.core.auction.dto.SellerAuctionSimpleInfo;
 import com.wootecam.luckyvickyauction.core.member.domain.Member;
 import com.wootecam.luckyvickyauction.core.member.fixture.MemberFixture;
 import com.wootecam.luckyvickyauction.core.payment.domain.BidHistory;
+import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
 import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSimpleInfo;
+import com.wootecam.luckyvickyauction.core.payment.entity.ReceiptEntity;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class MapperTest {
@@ -113,5 +116,43 @@ class MapperTest {
                 () -> assertEquals(auction.getStartedAt(), dto.startedAt()),
                 () -> assertEquals(auction.getFinishedAt(), dto.finishedAt())
         );
+    }
+
+    @Nested
+    class 영속성_엔티티_변환_케이스 {
+
+        @Test
+        public void 거래내역_영속성_엔티티를_도메인_엔티티로_변환하면_정보가_동일하다() {
+            // given
+            ReceiptEntity entity = ReceiptEntity.builder()
+                    .id(1L)
+                    .auctionId(2L)
+                    .productName("상품 이름")
+                    .price(1000L)
+                    .quantity(1L)
+                    .sellerId(3L)
+                    .buyerId(4L)
+                    .bidStatus(BidStatus.BID)
+                    .updatedAt(ZonedDateTime.now())
+                    .createdAt(ZonedDateTime.now().plusHours(1))
+                    .build();
+
+            // when
+            BidHistory domainEntity = Mapper.convertToReceipt(entity);
+
+            // then
+            assertAll(
+                    () -> assertEquals(entity.getId(), domainEntity.getId()),
+                    () -> assertEquals(entity.getAuctionId(), domainEntity.getAuctionId()),
+                    () -> assertEquals(entity.getProductName(), domainEntity.getProductName()),
+                    () -> assertEquals(entity.getPrice(), domainEntity.getPrice()),
+                    () -> assertEquals(entity.getQuantity(), domainEntity.getQuantity()),
+                    () -> assertEquals(entity.getSellerId(), domainEntity.getSellerId()),
+                    () -> assertEquals(entity.getBuyerId(), domainEntity.getBuyerId()),
+                    () -> assertEquals(entity.getBidStatus(), domainEntity.getBidStatus()),
+                    () -> assertEquals(entity.getCreatedAt(), domainEntity.getCreatedAt()),
+                    () -> assertEquals(entity.getUpdatedAt(), domainEntity.getUpdatedAt())
+            );
+        }
     }
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,8 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driverClassName: org.h2.Driver
+    username: sa
+    password: password
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## 📄 Summary
### 설정 및 의존성 작업
- [QueryDsl 5.0.0 의존성 추가](https://github.com/woowa-techcamp-2024/Team7-ELEVEN/commit/856d9f4515d7c3f7e19c5cdcc2492bd9ad51f22e)
- [h2 테스트 의존성 추가 및 설정](https://github.com/woowa-techcamp-2024/Team7-ELEVEN/commit/bad6ff82a39c8eeb153cdf94ba3ee51a6fcffef9)

### 코드 변경
- QueryDsl 을 적용한 저장 관련 클래스 생성
    - ReceiptQueryDslRepository inferface
    - ReceiptQueryDslRepositoryImpl -> Impl 이 불편하지만 인터페이스 확장하는 구조에서 이 방식 말고 다른 해결책을 생각하지 못했습니다.
    - ReceiptCoreRepository에서 QueryDsl 객체를 사용해서 바로 구현도 가능하지만 QueryDsl 역시 기술 의존적인 기술이기 때문에 도메인 엔티티와 영속성 엔티티를 매핑해주는 ReceiptCoreRepository는 기술에 의존적이지 않다고 생각이 되어서 분리했습니다.

- BidHistory 필드 타입 변경
    - `Member` 타입이었던 buyer, seller를 `Long`으로 변경하고 변수명도 buyerId, sellerId로 변경하였습니다.
    - 거래 내역이 구매자, 판매자에거 행위를 요청(method call)하는 요구사항이 없을 것으로 판단이 되어 제거하였습니다.
    - 특히 거래 내역을 조회하는 과정에서 불필요하게 판매자와 구매자의 메타 정보를 조회해야하는 구현이 필요하게 되어서 진행하였습니다.
    - 필드 변경으로 인해서 다수의 테스트 코드의 실패가 발생하였고 이를 수정하기 위한 변경 작업을 진행하였습니다.

- [구매자 거래 내역 목록 조회 쿼리 작성](https://github.com/woowa-techcamp-2024/Team7-ELEVEN/commit/399c786d2dbf3cfd0d767bcac6325b7715e43dbf)
   - ReceiptQueryDslRepositoryImpl 에서 SQL 쿼리를 QueryDsl를 이용하여 작성하였습니다.
   - 구매자 id가 일치하는지 확인하는 조건이 필요하기  때문에 BuyerReceiptSearchCondition에 buyerId 필드를 추가하였습니다.

### 버그
- [BuyerReceiptSearchCondition size 검증 로직이 항상 실패하는 오류 해결](https://github.com/woowa-techcamp-2024/Team7-ELEVEN/commit/2ff30245536ace851f16947e38a333958e8922ec)
    - BuyerReceiptSearchCondition에서 적합한 사이즈를 제공할 때도 실패처리하는 하는 현상을 발견하여 수정하였습니다.

### 테스트
- [test: 구매자 거래 내역 조회시 조회한 구매자의 내역만 볼 수 있다.](https://github.com/woowa-techcamp-2024/Team7-ELEVEN/commit/836d6fd6713541ab2331667e13a6e7a297bd720a)
- [test: 구매자 거래 내역 조회시 조회 개수 만큼 거래 내역을 조회한다.](https://github.com/woowa-techcamp-2024/Team7-ELEVEN/commit/035dfa3b831655d770e406e5957f357eb5dd3494)

## 🙋🏻 More

>


close #157