### PR TITLE
feat: 거래 내역은 영구적으로 저장 관리된다

### DIFF
--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptCoreRepository.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptCoreRepository.java
@@ -4,6 +4,7 @@ import com.wootecam.luckyvickyauction.core.payment.domain.BidHistory;
 import com.wootecam.luckyvickyauction.core.payment.domain.BidHistoryRepository;
 import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSearchCondition;
 import com.wootecam.luckyvickyauction.core.payment.dto.SellerReceiptSearchCondition;
+import com.wootecam.luckyvickyauction.core.payment.entity.ReceiptEntity;
 import com.wootecam.luckyvickyauction.global.util.Mapper;
 import java.util.List;
 import java.util.Optional;
@@ -18,12 +19,15 @@ public class ReceiptCoreRepository implements BidHistoryRepository {
 
     @Override
     public BidHistory save(BidHistory bidHistory) {
-        return null;
+        ReceiptEntity entity = Mapper.convertToReceiptEntity(bidHistory);
+        ReceiptEntity saved = receiptJpaRepository.save(entity);
+        return Mapper.convertToReceipt(saved);
     }
 
     @Override
     public Optional<BidHistory> findById(long bidHistoryId) {
-        return Optional.empty();
+        Optional<ReceiptEntity> found = receiptJpaRepository.findById(bidHistoryId);
+        return found.map(Mapper::convertToReceipt);
     }
 
     @Override

--- a/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
@@ -202,7 +202,7 @@ public final class Mapper {
                 .isShowStock(auction.isShowStock())
                 .build();
     }
-  
+
     public static Member convertToMember(MemberEntity entity) {
         return Member.builder()
                 .id(entity.getId())
@@ -223,4 +223,18 @@ public final class Mapper {
                 .build();
     }
 
+    public static ReceiptEntity convertToReceiptEntity(BidHistory bidHistory) {
+        return ReceiptEntity.builder()
+                .id(bidHistory.getId())
+                .productName(bidHistory.getProductName())
+                .price(bidHistory.getPrice())
+                .quantity(bidHistory.getQuantity())
+                .bidStatus(bidHistory.getBidStatus())
+                .auctionId(bidHistory.getAuctionId())
+                .sellerId(bidHistory.getSellerId())
+                .buyerId(bidHistory.getBuyerId())
+                .createdAt(bidHistory.getCreatedAt())
+                .updatedAt(bidHistory.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/test/java/com/wootecam/luckyvickyauction/core/auction/infra/AuctionCoreRepositoryTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/auction/infra/AuctionCoreRepositoryTest.java
@@ -19,62 +19,63 @@ class AuctionCoreRepositoryTest extends RepositoryTest {
     @Autowired
     private AuctionRepository auctionRepository;
 
-    @Autowired
-    private AuctionJpaRepository auctionJpaRepository;
+    @Nested
+    class 경매_조회_작업을_수행할_때 {
 
-    @Test
-    void 경매의_id로_경매를_조회한다() {
-        // given
-        ZonedDateTime now = ZonedDateTime.now();
-        AuctionEntity auction = AuctionEntity.builder()
-                .id(1L)
-                .sellerId(2L)
-                .productName("상품 이름")
-                .originPrice(1000L)
-                .currentPrice(1000L)
-                .originStock(100L)
-                .currentStock(100L)
-                .maximumPurchaseLimitCount(10L)
-                .pricePolicy(new ConstantPricePolicy(10L))
-                .variationDuration(Duration.ofMinutes(10L))
-                .startedAt(now)
-                .finishedAt(now.plusHours(1))
-                .isShowStock(true)
-                .build();
+        @Test
+        void 경매의_id로_경매를_조회한다() {
+            // given
+            ZonedDateTime now = ZonedDateTime.now();
+            Auction auction = Auction.builder()
+                    .id(1L)
+                    .sellerId(2L)
+                    .productName("상품 이름")
+                    .originPrice(1000L)
+                    .currentPrice(1000L)
+                    .originStock(100L)
+                    .currentStock(100L)
+                    .maximumPurchaseLimitCount(10L)
+                    .pricePolicy(new ConstantPricePolicy(10L))
+                    .variationDuration(Duration.ofMinutes(10L))
+                    .startedAt(now)
+                    .finishedAt(now.plusHours(1))
+                    .isShowStock(true)
+                    .build();
+            Auction saved = auctionRepository.save(auction);
 
-        // when
-        auctionJpaRepository.save(auction);
+            // when
+            Auction foundAuction = auctionRepository.findById(saved.getId()).get();
 
-        // then
-        AuctionEntity foundAuction = auctionJpaRepository.findById(auction.getId()).get();
-        assertAll(
-                () -> assertThat(foundAuction.getId()).isEqualTo(auction.getId()),
-                () -> assertThat(foundAuction.getSellerId()).isEqualTo(auction.getSellerId()),
-                () -> assertThat(foundAuction.getProductName()).isEqualTo(auction.getProductName()),
-                () -> assertThat(foundAuction.getOriginPrice()).isEqualTo(auction.getOriginPrice()),
-                () -> assertThat(foundAuction.getCurrentPrice()).isEqualTo(auction.getCurrentPrice()),
-                () -> assertThat(foundAuction.getOriginStock()).isEqualTo(auction.getOriginStock()),
-                () -> assertThat(foundAuction.getCurrentStock()).isEqualTo(auction.getCurrentStock()),
-                () -> assertThat(foundAuction.getMaximumPurchaseLimitCount()).isEqualTo(
-                        auction.getMaximumPurchaseLimitCount()),
-                () -> assertThat(foundAuction.getPricePolicy()).isEqualTo(auction.getPricePolicy()),
-                () -> assertThat(foundAuction.getVariationDuration()).isEqualTo(auction.getVariationDuration()),
-                () -> assertThat(foundAuction.getStartedAt()).isEqualTo(auction.getStartedAt()),
-                () -> assertThat(foundAuction.getFinishedAt()).isEqualTo(auction.getFinishedAt()),
-                () -> assertThat(foundAuction.isShowStock()).isEqualTo(auction.isShowStock())
-        );
-    }
+            // then
+            assertAll(
+                    () -> assertThat(foundAuction.getId()).isEqualTo(saved.getId()),
+                    () -> assertThat(foundAuction.getSellerId()).isEqualTo(saved.getSellerId()),
+                    () -> assertThat(foundAuction.getProductName()).isEqualTo(saved.getProductName()),
+                    () -> assertThat(foundAuction.getOriginPrice()).isEqualTo(saved.getOriginPrice()),
+                    () -> assertThat(foundAuction.getCurrentPrice()).isEqualTo(saved.getCurrentPrice()),
+                    () -> assertThat(foundAuction.getOriginStock()).isEqualTo(saved.getOriginStock()),
+                    () -> assertThat(foundAuction.getCurrentStock()).isEqualTo(saved.getCurrentStock()),
+                    () -> assertThat(foundAuction.getMaximumPurchaseLimitCount()).isEqualTo(
+                            saved.getMaximumPurchaseLimitCount()),
+                    () -> assertThat(foundAuction.getPricePolicy()).isEqualTo(saved.getPricePolicy()),
+                    () -> assertThat(foundAuction.getVariationDuration()).isEqualTo(saved.getVariationDuration()),
+                    () -> assertThat(foundAuction.getStartedAt()).isEqualTo(saved.getStartedAt()),
+                    () -> assertThat(foundAuction.getFinishedAt()).isEqualTo(saved.getFinishedAt()),
+                    () -> assertThat(foundAuction.isShowStock()).isEqualTo(saved.isShowStock())
+            );
+        }
 
-    @Test
-    void 경매의_id에_해당하는_경매가_없으면_empty를_반환한다() {
-        // given
-        Long notExistId = 1L;
+        @Test
+        void 경매의_id에_해당하는_경매가_없으면_empty를_반환한다() {
+            // given
+            Long notExistId = 1L;
 
-        // when
-        boolean isExist = auctionJpaRepository.findById(notExistId).isPresent();
+            // when
+            boolean isExist = auctionRepository.findById(notExistId).isPresent();
 
-        // then
-        assertThat(isExist).isFalse();
+            // then
+            assertThat(isExist).isFalse();
+        }
     }
 
     @Nested

--- a/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptCoreRepositoryTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/payment/infra/ReceiptCoreRepositoryTest.java
@@ -1,0 +1,133 @@
+package com.wootecam.luckyvickyauction.core.payment.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.wootecam.luckyvickyauction.context.RepositoryTest;
+import com.wootecam.luckyvickyauction.core.payment.domain.BidHistory;
+import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ReceiptCoreRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    ReceiptCoreRepository receiptCoreRepository;
+
+    @Nested
+    class 거래내역_조회_시에 {
+
+        @Test
+        void 거래내역의_id로_거래내역을_조회한다() {
+            // given
+            BidHistory bidHistory = BidHistory.builder()
+                    .id(1L)
+                    .productName("상품 이름")
+                    .price(1000L)
+                    .quantity(1L)
+                    .bidStatus(BidStatus.BID)
+                    .auctionId(1L)
+                    .sellerId(1L)
+                    .buyerId(2L)
+                    .createdAt(ZonedDateTime.now())
+                    .updatedAt(ZonedDateTime.now())
+                    .build();
+            BidHistory saved = receiptCoreRepository.save(bidHistory);
+
+            // when
+            BidHistory found = receiptCoreRepository.findById(saved.getId()).get();
+
+            // then
+            assertAll(
+                    () -> assertThat(found.getId()).isEqualTo(saved.getId()),
+                    () -> assertThat(found.getProductName()).isEqualTo(saved.getProductName()),
+                    () -> assertThat(found.getPrice()).isEqualTo(saved.getPrice()),
+                    () -> assertThat(found.getQuantity()).isEqualTo(saved.getQuantity()),
+                    () -> assertThat(found.getBidStatus()).isEqualTo(saved.getBidStatus()),
+                    () -> assertThat(found.getAuctionId()).isEqualTo(saved.getAuctionId()),
+                    () -> assertThat(found.getSellerId()).isEqualTo(saved.getSellerId()),
+                    () -> assertThat(found.getBuyerId()).isEqualTo(saved.getBuyerId()),
+                    () -> assertThat(found.getCreatedAt()).isEqualTo(saved.getCreatedAt()),
+                    () -> assertThat(found.getUpdatedAt()).isEqualTo(saved.getUpdatedAt())
+            );
+        }
+
+        @Test
+        void 거래내역_id에_해당하는_거래내역이_없으면_empty를_반환한다() {
+            // given
+            Long notExistId = 1L;
+
+            // when
+            boolean found = receiptCoreRepository.findById(notExistId).isPresent();
+
+            // then
+            assertThat(found).isFalse();
+        }
+    }
+
+    @Nested
+    class 거래내역_저장_시에 {
+
+        @Test
+        void 거래내역을_저장한다() {
+            // given
+            BidHistory bidHistory = BidHistory.builder()
+                    .id(1L)
+                    .productName("상품 이름")
+                    .price(1000L)
+                    .quantity(1L)
+                    .bidStatus(BidStatus.BID)
+                    .auctionId(1L)
+                    .sellerId(1L)
+                    .buyerId(2L)
+                    .createdAt(ZonedDateTime.now())
+                    .updatedAt(ZonedDateTime.now())
+                    .build();
+
+            // when
+            BidHistory saved = receiptCoreRepository.save(bidHistory);
+
+            // then
+            assertAll(
+                    () -> assertThat(saved.getId()).isEqualTo(bidHistory.getId()),
+                    () -> assertThat(saved.getProductName()).isEqualTo(bidHistory.getProductName()),
+                    () -> assertThat(saved.getPrice()).isEqualTo(bidHistory.getPrice()),
+                    () -> assertThat(saved.getQuantity()).isEqualTo(bidHistory.getQuantity()),
+                    () -> assertThat(saved.getBidStatus()).isEqualTo(bidHistory.getBidStatus()),
+                    () -> assertThat(saved.getAuctionId()).isEqualTo(bidHistory.getAuctionId()),
+                    () -> assertThat(saved.getSellerId()).isEqualTo(bidHistory.getSellerId()),
+                    () -> assertThat(saved.getBuyerId()).isEqualTo(bidHistory.getBuyerId()),
+                    () -> assertThat(saved.getCreatedAt()).isEqualTo(bidHistory.getCreatedAt()),
+                    () -> assertThat(saved.getUpdatedAt()).isEqualTo(bidHistory.getUpdatedAt())
+            );
+        }
+
+        @Test
+        void 이미_존재하는_id면_거래내역을_수정한다() {
+            // given
+            BidHistory bidHistory = BidHistory.builder()
+                    .id(1L)
+                    .productName("상품 이름")
+                    .price(1000L)
+                    .quantity(1L)
+                    .bidStatus(BidStatus.BID)
+                    .auctionId(1L)
+                    .sellerId(1L)
+                    .buyerId(2L)
+                    .createdAt(ZonedDateTime.now())
+                    .updatedAt(ZonedDateTime.now())
+                    .build();
+            receiptCoreRepository.save(bidHistory);
+
+            // when
+            bidHistory.markAsRefund();
+            BidHistory saved = receiptCoreRepository.save(bidHistory);
+
+            // then
+            BidHistory savedBidHistory = receiptCoreRepository.findById(saved.getId()).get();
+            assertThat(savedBidHistory.getBidStatus()).isEqualTo(BidStatus.REFUND);
+        }
+    }
+}

--- a/src/test/java/com/wootecam/luckyvickyauction/global/util/MapperReceiptTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/global/util/MapperReceiptTest.java
@@ -1,0 +1,93 @@
+package com.wootecam.luckyvickyauction.global.util;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.wootecam.luckyvickyauction.core.payment.domain.BidHistory;
+import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
+import com.wootecam.luckyvickyauction.core.payment.entity.ReceiptEntity;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @see <a href="https://github.com/woowa-techcamp-2024/Team7-ELEVEN/issues/112">#112</a>
+ */
+abstract class MapperReceiptTest {
+
+    @Nested
+    class 거래내역_영속성_엔티티를_도메인_엔티티로_변환하면 {
+
+        @Test
+        void 정보가_동일하다() {
+            // given
+            ReceiptEntity entity = ReceiptEntity.builder()
+                    .id(1L)
+                    .auctionId(2L)
+                    .productName("상품 이름")
+                    .price(1000L)
+                    .quantity(1L)
+                    .sellerId(3L)
+                    .buyerId(4L)
+                    .bidStatus(BidStatus.BID)
+                    .updatedAt(ZonedDateTime.now())
+                    .createdAt(ZonedDateTime.now().plusHours(1))
+                    .build();
+
+            // when
+            BidHistory domainEntity = Mapper.convertToReceipt(entity);
+
+            // then
+            assertAll(
+                    () -> assertEquals(entity.getId(), domainEntity.getId()),
+                    () -> assertEquals(entity.getAuctionId(), domainEntity.getAuctionId()),
+                    () -> assertEquals(entity.getProductName(), domainEntity.getProductName()),
+                    () -> assertEquals(entity.getPrice(), domainEntity.getPrice()),
+                    () -> assertEquals(entity.getQuantity(), domainEntity.getQuantity()),
+                    () -> assertEquals(entity.getSellerId(), domainEntity.getSellerId()),
+                    () -> assertEquals(entity.getBuyerId(), domainEntity.getBuyerId()),
+                    () -> assertEquals(entity.getBidStatus(), domainEntity.getBidStatus()),
+                    () -> assertEquals(entity.getCreatedAt(), domainEntity.getCreatedAt()),
+                    () -> assertEquals(entity.getUpdatedAt(), domainEntity.getUpdatedAt())
+            );
+        }
+    }
+
+    @Nested
+    class 거래내역_도메인_엔티티를_영속성_엔티티로_변환하면 {
+
+        @Test
+        void 정보가_동일하다() {
+            // given
+            BidHistory domainEntity = BidHistory.builder()
+                    .id(1L)
+                    .auctionId(2L)
+                    .productName("상품 이름")
+                    .price(1000L)
+                    .quantity(1L)
+                    .sellerId(3L)
+                    .buyerId(4L)
+                    .bidStatus(BidStatus.BID)
+                    .updatedAt(ZonedDateTime.now())
+                    .createdAt(ZonedDateTime.now().plusHours(1))
+                    .build();
+
+            // when
+            ReceiptEntity entity = Mapper.convertToReceiptEntity(domainEntity);
+
+            // then
+            assertAll(
+                    () -> assertEquals(domainEntity.getId(), entity.getId()),
+                    () -> assertEquals(domainEntity.getAuctionId(), entity.getAuctionId()),
+                    () -> assertEquals(domainEntity.getProductName(), entity.getProductName()),
+                    () -> assertEquals(domainEntity.getPrice(), entity.getPrice()),
+                    () -> assertEquals(domainEntity.getQuantity(), entity.getQuantity()),
+                    () -> assertEquals(domainEntity.getSellerId(), entity.getSellerId()),
+                    () -> assertEquals(domainEntity.getBuyerId(), entity.getBuyerId()),
+                    () -> assertEquals(domainEntity.getBidStatus(), entity.getBidStatus()),
+                    () -> assertEquals(domainEntity.getCreatedAt(), entity.getCreatedAt()),
+                    () -> assertEquals(domainEntity.getUpdatedAt(), entity.getUpdatedAt())
+            );
+        }
+    }
+}

--- a/src/test/java/com/wootecam/luckyvickyauction/global/util/MapperTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/global/util/MapperTest.java
@@ -11,9 +11,7 @@ import com.wootecam.luckyvickyauction.core.auction.dto.SellerAuctionSimpleInfo;
 import com.wootecam.luckyvickyauction.core.member.domain.Member;
 import com.wootecam.luckyvickyauction.core.member.fixture.MemberFixture;
 import com.wootecam.luckyvickyauction.core.payment.domain.BidHistory;
-import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
 import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSimpleInfo;
-import com.wootecam.luckyvickyauction.core.payment.entity.ReceiptEntity;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Nested;
@@ -119,46 +117,6 @@ class MapperTest {
     }
 
     @Nested
-    class 영속성_엔티티_변환_케이스 {
-
-
-
-        @Test
-        public void 거래내역_영속성_엔티티를_도메인_엔티티로_변환하면_정보가_동일하다() {
-            // given
-            ReceiptEntity entity = ReceiptEntity.builder()
-                    .id(1L)
-                    .auctionId(2L)
-                    .productName("상품 이름")
-                    .price(1000L)
-                    .quantity(1L)
-                    .sellerId(3L)
-                    .buyerId(4L)
-                    .bidStatus(BidStatus.BID)
-                    .updatedAt(ZonedDateTime.now())
-                    .createdAt(ZonedDateTime.now().plusHours(1))
-                    .build();
-
-            // when
-            BidHistory domainEntity = Mapper.convertToReceipt(entity);
-
-            // then
-            assertAll(
-                    () -> assertEquals(entity.getId(), domainEntity.getId()),
-                    () -> assertEquals(entity.getAuctionId(), domainEntity.getAuctionId()),
-                    () -> assertEquals(entity.getProductName(), domainEntity.getProductName()),
-                    () -> assertEquals(entity.getPrice(), domainEntity.getPrice()),
-                    () -> assertEquals(entity.getQuantity(), domainEntity.getQuantity()),
-                    () -> assertEquals(entity.getSellerId(), domainEntity.getSellerId()),
-                    () -> assertEquals(entity.getBuyerId(), domainEntity.getBuyerId()),
-                    () -> assertEquals(entity.getBidStatus(), domainEntity.getBidStatus()),
-                    () -> assertEquals(entity.getCreatedAt(), domainEntity.getCreatedAt()),
-                    () -> assertEquals(entity.getUpdatedAt(), domainEntity.getUpdatedAt())
-            );
-        }
-    }
-
-    @Nested
     class 회원정보_맵핑시에 extends MapperMemberTest {
     }
 
@@ -166,4 +124,8 @@ class MapperTest {
     class 경매_맵핑시에 extends MapperAuctionTest {
     }
 
+
+    @Nested
+    class 거래내역_맵핑시에 extends MapperReceiptTest {
+    }
 }


### PR DESCRIPTION
## 📄 Summary

- **거래 내역 영속성 로직 구현**
  - [x] 영속성 계층에서 활용되는 `ReceiptEntity` 구현
  - [x] Application 계층과 Persistence 계층간 데이터 교환을 위해 `ReceiptRepository` 구현
      - [x] save, findById 구현
  - [x] Domain <-> PersistenceEntity 변환을 위해 `Mapper`에 새로운 로직 추가 구현  
- **거래 내역 영구저장 로직 호출 테스트 작성**
  - [x] `ReceiptCoreRepositoryTest` 추가 
  - [x] `MapperTest`에 새로운 변환 로직 테스트 추가
      - [x] 추상 클래스로 추출 후 테스트 추가 (도메인 -> 엔티티, 엔티티 -> 도메인)


## 🙋🏻 More

팀원분들 코드 보고 배우면서 하니까 쉬운 태스크네요!

close #112