### PR TITLE
feat: 구매자는 REST API를 통해서 경매를 상세 조회 요청을 할 수 있다.

### DIFF
--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/controller/BuyerAuctionController.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/controller/BuyerAuctionController.java
@@ -3,6 +3,7 @@ package com.wootecam.luckyvickyauction.core.auction.controller;
 import com.wootecam.luckyvickyauction.core.auction.dto.AuctionSearchCondition;
 import com.wootecam.luckyvickyauction.core.auction.dto.BuyerAuctionInfo;
 import com.wootecam.luckyvickyauction.core.auction.dto.BuyerAuctionSimpleInfo;
+import com.wootecam.luckyvickyauction.core.auction.service.AuctionService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -11,11 +12,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-// @RestController  // TODO: [선행 @Repository가 생길 때, 주석을 풀 것] [writeAt: 2024/08/16/16:12] [writeBy: chhs2131]
+@RestController
 @RequestMapping("/auctions")
 @RequiredArgsConstructor
 public class BuyerAuctionController {
+
+    private final AuctionService auctionService;
 
     // 사용자는 경매 목록을 조회한다.
     @GetMapping
@@ -26,9 +30,8 @@ public class BuyerAuctionController {
 
     // 사용자는 경매의 상세정보를 조회한다.
     @GetMapping("/{auctionId}")
-    public BuyerAuctionInfo getAuction(@PathVariable Long auctionId) {
-        // TODO: [Task에 맞게 로직 구현할 것!] [writeAt: 2024/08/16/17:40] [writeBy: chhs2131]
-        throw new UnsupportedOperationException();
+    public BuyerAuctionInfo getAuction(@PathVariable("auctionId") Long auctionId) {
+        return auctionService.getBuyerAuction(auctionId);
     }
 
     // 사용자는 경매에 입찰한다.

--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/controller/BuyerAuctionController.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/controller/BuyerAuctionController.java
@@ -6,6 +6,7 @@ import com.wootecam.luckyvickyauction.core.auction.dto.BuyerAuctionSimpleInfo;
 import com.wootecam.luckyvickyauction.core.auction.service.AuctionService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,8 +31,9 @@ public class BuyerAuctionController {
 
     // 사용자는 경매의 상세정보를 조회한다.
     @GetMapping("/{auctionId}")
-    public BuyerAuctionInfo getAuction(@PathVariable("auctionId") Long auctionId) {
-        return auctionService.getBuyerAuction(auctionId);
+    public ResponseEntity<BuyerAuctionInfo> getAuction(@PathVariable("auctionId") Long auctionId) {
+        BuyerAuctionInfo result = auctionService.getBuyerAuction(auctionId);
+        return ResponseEntity.ok(result);
     }
 
     // 사용자는 경매에 입찰한다.

--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/dto/BuyerAuctionInfo.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/dto/BuyerAuctionInfo.java
@@ -17,13 +17,12 @@ public record BuyerAuctionInfo(
         String productName,
         long originPrice,
         long currentPrice,
-        long stock,
+        Long stock,
         long maximumPurchaseLimitCount,
         PricePolicy pricePolicy,
         Duration variationDuration,
         ZonedDateTime startedAt,
-        ZonedDateTime finishedAt,
-        boolean isShowStock
+        ZonedDateTime finishedAt
 ) {
 
     public static final String ERROR_PRODUCT_NAME = "상품 이름은 비어있을 수 없습니다.";

--- a/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
@@ -60,14 +60,14 @@ public final class Mapper {
     }
 
     /**
-     * Auction을 BuyerAuctionInfo로 변환 - stock 노출 여부를 확인하여 노출 여부에 따라 stock을 노출하거나 노출하지 않습니다 - 만약 isShowStock이 false라면
-     * stock을 0으로 지정해 구매자에게 보이지 않게 합니다
+     * Auction을 BuyerAuctionInfo로 변환 <br>
+     * - stock 노출 여부를 확인하여 노출 여부에 따라 stock을 노출하거나 노출하지 않습니다.
      *
      * @param auction
      * @return
      */
     public static BuyerAuctionInfo convertToBuyerAuctionInfo(Auction auction) {
-        long stock = auction.isShowStock() ? auction.getCurrentStock() : 0;
+        Long stock = auction.isShowStock() ? auction.getCurrentStock() : null;
 
         return BuyerAuctionInfo.builder()
                 .auctionId(auction.getId())
@@ -81,7 +81,6 @@ public final class Mapper {
                 .variationDuration(auction.getVariationDuration())
                 .startedAt(auction.getStartedAt())
                 .finishedAt(auction.getFinishedAt())
-                .isShowStock(auction.isShowStock())
                 .build();
     }
 

--- a/src/test/java/com/wootecam/luckyvickyauction/core/auction/controller/BuyerAuctionControllerTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/auction/controller/BuyerAuctionControllerTest.java
@@ -36,7 +36,7 @@ class BuyerAuctionControllerTest extends DocumentationTest {
                     .when()
                     .get("/auctions/{auctionId}", auctionId.toString())
                     .then().log().all()
-                    .apply(document("auctions/{auctionId}",
+                    .apply(document("auctions/{auctionId}/constant_policy/success",
                             responseFields(
                                     fieldWithPath("auctionId").description("경매 ID"),
                                     fieldWithPath("sellerId").description("판매자 ID"),
@@ -75,7 +75,7 @@ class BuyerAuctionControllerTest extends DocumentationTest {
                     .when()
                     .get("/auctions/{auctionId}", auctionId.toString())
                     .then().log().all()
-                    .apply(document("auctions/{auctionId}",
+                    .apply(document("auctions/{auctionId}/percentage_policy/success",
                             responseFields(
                                     fieldWithPath("auctionId").description("경매 ID"),
                                     fieldWithPath("sellerId").description("판매자 ID"),

--- a/src/test/java/com/wootecam/luckyvickyauction/core/auction/controller/BuyerAuctionControllerTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/auction/controller/BuyerAuctionControllerTest.java
@@ -1,0 +1,99 @@
+package com.wootecam.luckyvickyauction.core.auction.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import com.wootecam.luckyvickyauction.core.auction.domain.PricePolicy;
+import com.wootecam.luckyvickyauction.core.auction.dto.BuyerAuctionInfo;
+import com.wootecam.luckyvickyauction.core.auction.fixture.BuyerAuctionInfoFixture;
+import com.wootecam.luckyvickyauction.documentation.DocumentationTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+class BuyerAuctionControllerTest extends DocumentationTest {
+
+    @Nested
+    class 구매자_경매_단건_조회_API {
+
+        @Test
+        void ConstantPolicy_경매_조회시() {
+            // given
+            Long auctionId = 1L;
+            BuyerAuctionInfo response = BuyerAuctionInfoFixture.create()
+                    .auctionId(auctionId)
+                    .pricePolicy(PricePolicy.createConstantPricePolicy(10))
+                    .build();
+            given(auctionService.getBuyerAuction(auctionId))
+                    .willReturn(response);
+
+            // when
+            docsGiven
+                    .accept(MediaType.APPLICATION_JSON_VALUE)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .when()
+                    .get("/auctions/{auctionId}", auctionId.toString())
+                    .then().log().all()
+                    .apply(document("auctions/{auctionId}",
+                            responseFields(
+                                    fieldWithPath("auctionId").description("경매 ID"),
+                                    fieldWithPath("sellerId").description("판매자 ID"),
+                                    fieldWithPath("productName").description("상품 이름"),
+                                    fieldWithPath("originPrice").description("상품 원가"),
+                                    fieldWithPath("currentPrice").description("현재 가격"),
+                                    fieldWithPath("stock").description("현재 재고"),
+                                    fieldWithPath("maximumPurchaseLimitCount").description("최대 구매 수량 제한"),
+                                    fieldWithPath("pricePolicy").description("가격 정책"),
+                                    fieldWithPath("pricePolicy.type").description("가격 정책 타입"),
+                                    fieldWithPath("pricePolicy.variationWidth").description("절대 변동 폭"),
+                                    fieldWithPath("variationDuration").description("가격 변동 주기"),
+                                    fieldWithPath("startedAt").description("경매 시작 시간"),
+                                    fieldWithPath("finishedAt").description("경매 종료 시간")
+                            )
+                    ))
+                    .statusCode(200);
+
+        }
+
+        @Test
+        void PercentagePolicy_경매_조회시() {
+            // given
+            Long auctionId = 1L;
+            BuyerAuctionInfo response = BuyerAuctionInfoFixture.create()
+                    .auctionId(auctionId)
+                    .pricePolicy(PricePolicy.createPercentagePricePolicy(10))
+                    .build();
+            given(auctionService.getBuyerAuction(auctionId))
+                    .willReturn(response);
+
+            // when
+            docsGiven
+                    .accept(MediaType.APPLICATION_JSON_VALUE)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .when()
+                    .get("/auctions/{auctionId}", auctionId.toString())
+                    .then().log().all()
+                    .apply(document("auctions/{auctionId}",
+                            responseFields(
+                                    fieldWithPath("auctionId").description("경매 ID"),
+                                    fieldWithPath("sellerId").description("판매자 ID"),
+                                    fieldWithPath("productName").description("상품 이름"),
+                                    fieldWithPath("originPrice").description("상품 원가"),
+                                    fieldWithPath("currentPrice").description("현재 가격"),
+                                    fieldWithPath("stock").description("현재 재고"),
+                                    fieldWithPath("maximumPurchaseLimitCount").description("최대 구매 수량 제한"),
+                                    fieldWithPath("pricePolicy").description("가격 정책"),
+                                    fieldWithPath("pricePolicy.type").description("가격 정책 타입"),
+                                    fieldWithPath("pricePolicy.discountRate").description("가격 변동 할인율"),
+                                    fieldWithPath("variationDuration").description("가격 변동 주기"),
+                                    fieldWithPath("startedAt").description("경매 시작 시간"),
+                                    fieldWithPath("finishedAt").description("경매 종료 시간")
+                            )
+                    ))
+                    .statusCode(200);
+
+        }
+    }
+}

--- a/src/test/java/com/wootecam/luckyvickyauction/core/auction/dto/BuyerAuctionInfoTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/auction/dto/BuyerAuctionInfoTest.java
@@ -23,16 +23,16 @@ public class BuyerAuctionInfoTest {
         return Stream.of(
                 Arguments.of("상품 이름은 비어있을 수 없습니다.",
                         ErrorCode.A001, 1L, 1L, "", 10000, 10000, 10, 10, Duration.ofMinutes(1L), ZonedDateTime.now(),
-                        ZonedDateTime.now(), true),
+                        ZonedDateTime.now()),
                 Arguments.of("상품 원가는 0보다 커야 합니다. 상품 원가: 0",
                         ErrorCode.A002, 1L, 1L, "상품이름", 0, 10000, 10, 10, Duration.ofMinutes(1L), ZonedDateTime.now(),
-                        ZonedDateTime.now(), true),
+                        ZonedDateTime.now()),
                 Arguments.of("현재 가격은 0보다 커야 합니다. 현재 가격: 0",
                         ErrorCode.A013, 1L, 1L, "상품이름", 10000, 0, 10, 10, Duration.ofMinutes(1L), ZonedDateTime.now(),
-                        ZonedDateTime.now(), true),
+                        ZonedDateTime.now()),
                 Arguments.of("최대 구매 수량 제한은 0보다 커야 합니다. 최대 구매 수량 제한: 0",
                         ErrorCode.A003, 1L, 1L, "상품이름", 10000, 10000, 10, 0, Duration.ofMinutes(1L),
-                        ZonedDateTime.now(), ZonedDateTime.now(), true)
+                        ZonedDateTime.now(), ZonedDateTime.now())
         );
     }
 
@@ -44,7 +44,7 @@ public class BuyerAuctionInfoTest {
         String productName = "상품이름";
         long originPrice = 10000;
         long currentPrice = 10000;
-        int stock = 10;
+        long stock = 10;
         int maximumPurchaseLimitCount = 10;
 
         int variationWidth = 1000;
@@ -57,7 +57,7 @@ public class BuyerAuctionInfoTest {
         // when
         BuyerAuctionInfo buyerAuctionInfo = new BuyerAuctionInfo(auctionId, sellerId, productName, originPrice,
                 currentPrice, stock,
-                maximumPurchaseLimitCount, pricePolicy, varitationDuration, startedAt, finishedAt, true);
+                maximumPurchaseLimitCount, pricePolicy, varitationDuration, startedAt, finishedAt);
 
         // then
         assertAll(
@@ -71,13 +71,12 @@ public class BuyerAuctionInfoTest {
                 () -> assertThat(buyerAuctionInfo.pricePolicy()).isEqualTo(pricePolicy),
                 () -> assertThat(buyerAuctionInfo.variationDuration()).isEqualTo(varitationDuration),
                 () -> assertThat(buyerAuctionInfo.startedAt()).isEqualTo(startedAt),
-                () -> assertThat(buyerAuctionInfo.finishedAt()).isEqualTo(finishedAt),
-                () -> assertThat(buyerAuctionInfo.isShowStock()).isTrue()
+                () -> assertThat(buyerAuctionInfo.finishedAt()).isEqualTo(finishedAt)
         );
     }
 
     @Test
-    void 재고_노출이_비활성화된_경매는_재고를_0으로_처리한다() {
+    void 재고_노출이_비활성화된_경매는_재고는_null이다() {
         // given
         Long auctionId = 1L;
         Long sellerId = 1L;
@@ -113,7 +112,7 @@ public class BuyerAuctionInfoTest {
         BuyerAuctionInfo buyerAuctionInfo = Mapper.convertToBuyerAuctionInfo(auction);
 
         // then
-        assertThat(buyerAuctionInfo.stock()).isEqualTo(0);
+        assertThat(buyerAuctionInfo.stock()).isEqualTo(null);
     }
 
     @ParameterizedTest
@@ -130,8 +129,7 @@ public class BuyerAuctionInfoTest {
             int maximumPurchaseLimitCount,
             Duration variationDuration,
             ZonedDateTime startedAt,
-            ZonedDateTime finishedAt,
-            boolean isShowStock
+            ZonedDateTime finishedAt
     ) {
         // expect
         assertThatThrownBy(() -> BuyerAuctionInfo.builder()
@@ -146,7 +144,6 @@ public class BuyerAuctionInfoTest {
                 .variationDuration(variationDuration)
                 .startedAt(startedAt)
                 .finishedAt(finishedAt)
-                .isShowStock(isShowStock)
                 .build()
         )
                 .isInstanceOf(BadRequestException.class)

--- a/src/test/java/com/wootecam/luckyvickyauction/core/auction/fixture/BuyerAuctionInfoFixture.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/auction/fixture/BuyerAuctionInfoFixture.java
@@ -1,0 +1,96 @@
+package com.wootecam.luckyvickyauction.core.auction.fixture;
+
+import com.wootecam.luckyvickyauction.core.auction.domain.PricePolicy;
+import com.wootecam.luckyvickyauction.core.auction.dto.BuyerAuctionInfo;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class BuyerAuctionInfoFixture {
+    private Long auctionId = 1L;
+    private Long sellerId = 2L;
+    private String productName = "테스트 상품";
+    private long originPrice = 10000;
+    private long currentPrice = 5000;
+    private Long stock = 100L;
+    private long maximumPurchaseLimitCount = 10;
+    private PricePolicy pricePolicy = PricePolicy.createPercentagePricePolicy(10);
+    private Duration variationDuration = Duration.ofMinutes(1L);
+    private ZonedDateTime startedAt = ZonedDateTime.of(2024, 8, 15, 14, 18, 0, 0, ZoneId.of("Asia/Seoul"));
+    private ZonedDateTime finishedAt = ZonedDateTime.of(2024, 8, 15, 15, 18, 0, 0, ZoneId.of("Asia/Seoul"));
+
+    public static BuyerAuctionInfoFixture create() {
+        return new BuyerAuctionInfoFixture();
+    }
+
+    public BuyerAuctionInfoFixture auctionId(Long auctionId) {
+        this.auctionId = auctionId;
+        return this;
+    }
+
+    public BuyerAuctionInfoFixture sellerId(Long sellerId) {
+        this.sellerId = sellerId;
+        return this;
+    }
+
+    public BuyerAuctionInfoFixture productName(String productName) {
+        this.productName = productName;
+        return this;
+    }
+
+    public BuyerAuctionInfoFixture originPrice(long originPrice) {
+        this.originPrice = originPrice;
+        return this;
+    }
+
+    public BuyerAuctionInfoFixture currentPrice(long currentPrice) {
+        this.currentPrice = currentPrice;
+        return this;
+    }
+
+    public BuyerAuctionInfoFixture stock(Long stock) {
+        this.stock = stock;
+        return this;
+    }
+
+    public BuyerAuctionInfoFixture maximumPurchaseLimitCount(long maximumPurchaseLimitCount) {
+        this.maximumPurchaseLimitCount = maximumPurchaseLimitCount;
+        return this;
+    }
+
+    public BuyerAuctionInfoFixture pricePolicy(PricePolicy pricePolicy) {
+        this.pricePolicy = pricePolicy;
+        return this;
+    }
+
+    public BuyerAuctionInfoFixture variationDuration(Duration variationDuration) {
+        this.variationDuration = variationDuration;
+        return this;
+    }
+
+    public BuyerAuctionInfoFixture startedAt(ZonedDateTime startedAt) {
+        this.startedAt = startedAt;
+        return this;
+    }
+
+    public BuyerAuctionInfoFixture finishedAt(ZonedDateTime finishedAt) {
+        this.finishedAt = finishedAt;
+        return this;
+    }
+
+    public BuyerAuctionInfo build() {
+        return new BuyerAuctionInfo(
+                auctionId,
+                sellerId,
+                productName,
+                originPrice,
+                currentPrice,
+                stock,
+                maximumPurchaseLimitCount,
+                pricePolicy,
+                variationDuration,
+                startedAt,
+                finishedAt
+        );
+    }
+}

--- a/src/test/java/com/wootecam/luckyvickyauction/documentation/DocumentationTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/documentation/DocumentationTest.java
@@ -3,6 +3,7 @@ package com.wootecam.luckyvickyauction.documentation;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 
+import com.wootecam.luckyvickyauction.core.auction.controller.BuyerAuctionController;
 import com.wootecam.luckyvickyauction.core.auction.controller.SellerAuctionController;
 import com.wootecam.luckyvickyauction.core.auction.service.AuctionService;
 import com.wootecam.luckyvickyauction.core.member.controller.AuthController;
@@ -26,6 +27,7 @@ import org.springframework.web.context.WebApplicationContext;
 @WebMvcTest({
         FakeErrorCodeController.class,
         AuthController.class,
+        BuyerAuctionController.class,
         SellerAuctionController.class
 })
 @Import(JsonConfig.class)


### PR DESCRIPTION
## 📄 Summary
### 변경 사항
- [BuyerAuctionInfo isShowStock 필드 제거](https://github.com/woowa-techcamp-2024/Team7-ELEVEN/commit/67545445fb6c3c6ac63adec19cbf2e4b5a944502)
    - 구매자 조회 전용 DTO에서 isShowStock 정책은 노출하지 않도록 하는 것이 좋다고 생각해서 리펙토링을 진행했습니다.
- [구매자 경매 상세 정보 Controller 구현](https://github.com/woowa-techcamp-2024/Team7-ELEVEN/commit/ac1662bc2bae504e9436557b2ae7513a607175dc)

### 테스트
- [구매자 경매 단건 조회 API 테스트 작성](https://github.com/woowa-techcamp-2024/Team7-ELEVEN/commit/2b08a321c36ec11018be838d8bc08a0b059dd5ed)
    - 경매 가격 정책이 절대값 할인 정책인 경우
    - 경매 가격 정책이 퍼센트 할인 정책인 경우
- [BuyerAuctionInfoFixture 생성](https://github.com/woowa-techcamp-2024/Team7-ELEVEN/commit/3b9e4c81ebf928078c25b42e21833d154fe839de)
    - 빌더 패턴을 적용하여 동적으로 원하는 Fixture를 생성할 수 있도록 합니다.
    - 값을 초기화하지 않는다면 기본으로 설정한 테스트 값이 세팅됩니다.

## 🙋🏻 More
- #214 PR 의 작업이 머지가 되어야 합니다.
    - controller, service 등록, DocumentTest 설정 등이 미반영된 상태입니다.
    - 선행 PR이 머지되면 업데이트를 진행한 이후 버그가 있는지 확인할 예정입니다.


close #137