### PR TITLE
feat: 사용자는 REST API를 통해서 거래 내역 목록 조회 요청을 보낼 수 있다.

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -8,4 +8,5 @@
 :docinfo: shared-head
 
 include::auth.adoc[]
+include::receipts.adoc[]
 include::errorCode.adoc[]

--- a/src/docs/asciidoc/receipts.adoc
+++ b/src/docs/asciidoc/receipts.adoc
@@ -1,0 +1,8 @@
+[[Receipts]]
+== 거래 이력
+
+=== 구매자 거래이력 확인
+operation::receipts/getReceipts/success[snippets='http-request,http-response,request-fields']
+
+=== 판매자 거래이력 확인
+operation::receipts/getSellerReceipts/success[snippets='http-request,http-response,request-fields']

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/controller/ReceiptController.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/controller/ReceiptController.java
@@ -4,28 +4,35 @@ import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSearchConditi
 import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSimpleInfo;
 import com.wootecam.luckyvickyauction.core.payment.dto.SellerReceiptSearchCondition;
 import com.wootecam.luckyvickyauction.core.payment.dto.SellerReceiptSimpleInfo;
+import com.wootecam.luckyvickyauction.core.payment.service.BidHistoryService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-// @RestController  // TODO: [선행 @Repository가 생길 때, 주석을 풀 것] [writeAt: 2024/08/16/16:12] [writeBy: chhs2131]
+@RestController
 @RequestMapping("/receipts")
 @RequiredArgsConstructor
 public class ReceiptController {
 
+    private final BidHistoryService bidHistoryService;
+
     // 구매자는 자신의 거래 이력 목록을 조회할 수 있다.
     @GetMapping
-    public List<BuyerReceiptSimpleInfo> getReceipts(@RequestBody BuyerReceiptSearchCondition condition) {
-        // TODO: [Task에 맞게 로직 구현할 것!] [writeAt: 2024/08/16/17:40] [writeBy: chhs2131]
-        throw new UnsupportedOperationException();
+    public ResponseEntity<List<BuyerReceiptSimpleInfo>> getReceipts(
+            @RequestBody BuyerReceiptSearchCondition condition) {
+        List<BuyerReceiptSimpleInfo> infos = bidHistoryService.getBuyerReceiptSimpleInfos(condition);
+        return ResponseEntity.ok(infos);
     }
 
     // 판매자는 자신의 거래 이력 목록을 조회할 수 있다.
     @GetMapping("/seller")
-    public List<SellerReceiptSimpleInfo> getSellerReceipts(@RequestBody SellerReceiptSearchCondition condition) {
-        // TODO: [Task에 맞게 로직 구현할 것!] [writeAt: 2024/08/16/17:40] [writeBy: chhs2131]
-        throw new UnsupportedOperationException();
+    public ResponseEntity<List<SellerReceiptSimpleInfo>> getSellerReceipts(
+            @RequestBody SellerReceiptSearchCondition condition) {
+        List<SellerReceiptSimpleInfo> infos = bidHistoryService.getSellerReceiptSimpleInfos(condition);
+        return ResponseEntity.ok(infos);
     }
 }

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/controller/ReceiptController.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/controller/ReceiptController.java
@@ -2,6 +2,8 @@ package com.wootecam.luckyvickyauction.core.payment.controller;
 
 import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSearchCondition;
 import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSimpleInfo;
+import com.wootecam.luckyvickyauction.core.payment.dto.SellerReceiptSearchCondition;
+import com.wootecam.luckyvickyauction.core.payment.dto.SellerReceiptSimpleInfo;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,11 +15,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequiredArgsConstructor
 public class ReceiptController {
 
-    // 사용자는 자신의 거래 이력 목록을 조회할 수 있다.
+    // 구매자는 자신의 거래 이력 목록을 조회할 수 있다.
     @GetMapping
     public List<BuyerReceiptSimpleInfo> getReceipts(@RequestBody BuyerReceiptSearchCondition condition) {
         // TODO: [Task에 맞게 로직 구현할 것!] [writeAt: 2024/08/16/17:40] [writeBy: chhs2131]
         throw new UnsupportedOperationException();
     }
 
+    // 판매자는 자신의 거래 이력 목록을 조회할 수 있다.
+    @GetMapping("/seller")
+    public List<SellerReceiptSimpleInfo> getSellerReceipts(@RequestBody SellerReceiptSearchCondition condition) {
+        // TODO: [Task에 맞게 로직 구현할 것!] [writeAt: 2024/08/16/17:40] [writeBy: chhs2131]
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSimpleInfo.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSimpleInfo.java
@@ -6,17 +6,19 @@ import lombok.Builder;
 /**
  * 구매자가 거래 내역 목록을 조회할 때, 노출되는 각 내역의 데이터를 나타내는 dto 입니다.
  *
- * @param id        거내 내역 식별자입니다.
- * @param type      거래 타입 {@link BidStatus}
- * @param auctionId 구매한 경매의 식별자입니다.
- * @param quantity  구매 수량
- * @param price     구매 가격
+ * @param id          거내 내역 식별자입니다.
+ * @param auctionId   구매한 경매의 식별자입니다.
+ * @param type        거래 타입 {@link BidStatus}
+ * @param productName 상품명
+ * @param quantity    구매 수량
+ * @param price       구매 가격
  */
 @Builder
 public record BuyerReceiptSimpleInfo(
         long id,
-        BidStatus type,
         long auctionId,
+        BidStatus type,
+        String productName,
         long quantity,
         long price
 ) {

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSimpleInfo.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/BuyerReceiptSimpleInfo.java
@@ -1,6 +1,7 @@
 package com.wootecam.luckyvickyauction.core.payment.dto;
 
 import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
+import lombok.Builder;
 
 /**
  * 구매자가 거래 내역 목록을 조회할 때, 노출되는 각 내역의 데이터를 나타내는 dto 입니다.
@@ -11,6 +12,7 @@ import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
  * @param quantity  구매 수량
  * @param price     구매 가격
  */
+@Builder
 public record BuyerReceiptSimpleInfo(
         long id,
         BidStatus type,

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/SellerReceiptSimpleInfo.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/dto/SellerReceiptSimpleInfo.java
@@ -1,6 +1,7 @@
 package com.wootecam.luckyvickyauction.core.payment.dto;
 
 import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
+import lombok.Builder;
 
 /**
  * 판매자가 자신의 경매와 관련있는 거래 내역 목록을 조회 시 사용하는 dto
@@ -12,6 +13,7 @@ import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
  * @param price       거래 가격
  * @param quantity    거래 수량
  */
+@Builder
 public record SellerReceiptSimpleInfo(
         Long id,
         Long auctionId,

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/service/BidHistoryService.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/service/BidHistoryService.java
@@ -14,8 +14,9 @@ import com.wootecam.luckyvickyauction.global.exception.UnauthorizedException;
 import com.wootecam.luckyvickyauction.global.util.Mapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
-// TODO [추후 Controller로 책임 변경] [writeAt: 2024/08/16/16:31] [writeBy: minseok-oh]
+@Service
 @RequiredArgsConstructor
 public class BidHistoryService {
 

--- a/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
@@ -109,24 +109,25 @@ public final class Mapper {
     }
 
     public static BuyerReceiptSimpleInfo convertToBuyerReceiptSimpleInfo(BidHistory history) {
-        return new BuyerReceiptSimpleInfo(
-                history.getId(),
-                history.getBidStatus(),
-                history.getAuctionId(),
-                history.getQuantity(),
-                history.getPrice()
-        );
+        return BuyerReceiptSimpleInfo.builder()
+                .id(history.getId())
+                .auctionId(history.getAuctionId())
+                .type(history.getBidStatus())
+                .productName(history.getProductName())
+                .price(history.getPrice())
+                .quantity(history.getQuantity())
+                .build();
     }
 
     public static SellerReceiptSimpleInfo convertToSellerReceiptSimpleInfo(BidHistory history) {
-        return new SellerReceiptSimpleInfo(
-                history.getId(),
-                history.getAuctionId(),
-                history.getBidStatus(),
-                history.getProductName(),
-                history.getPrice(),
-                history.getQuantity()
-        );
+        return SellerReceiptSimpleInfo.builder()
+                .id(history.getId())
+                .auctionId(history.getAuctionId())
+                .type(history.getBidStatus())
+                .productName(history.getProductName())
+                .price(history.getPrice())
+                .quantity(history.getQuantity())
+                .build();
     }
 
     public static BuyerAuctionSimpleInfo convertToBuyerAuctionSimpleInfo(Auction auction) {

--- a/src/test/java/com/wootecam/luckyvickyauction/documentation/DocumentationTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/documentation/DocumentationTest.java
@@ -5,6 +5,8 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 
 import com.wootecam.luckyvickyauction.core.member.controller.AuthController;
 import com.wootecam.luckyvickyauction.core.member.service.MemberService;
+import com.wootecam.luckyvickyauction.core.payment.controller.ReceiptController;
+import com.wootecam.luckyvickyauction.core.payment.service.BidHistoryService;
 import com.wootecam.luckyvickyauction.documentation.errorcode.FakeErrorCodeController;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
@@ -21,7 +23,8 @@ import org.springframework.web.context.WebApplicationContext;
 
 @WebMvcTest({
         FakeErrorCodeController.class,
-        AuthController.class
+        AuthController.class,
+        ReceiptController.class,
 })
 @ExtendWith(RestDocumentationExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -31,6 +34,9 @@ public class DocumentationTest {
 
     @MockBean
     protected MemberService memberService;
+
+    @MockBean
+    protected BidHistoryService bidHistoryService;
 
     @BeforeEach
     void setUp(final WebApplicationContext webApplicationContext,

--- a/src/test/java/com/wootecam/luckyvickyauction/documentation/DocumentationTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/documentation/DocumentationTest.java
@@ -9,6 +9,7 @@ import com.wootecam.luckyvickyauction.core.auction.service.AuctionService;
 import com.wootecam.luckyvickyauction.core.member.controller.AuthController;
 import com.wootecam.luckyvickyauction.core.member.service.MemberService;
 import com.wootecam.luckyvickyauction.core.payment.controller.ReceiptController;
+import com.wootecam.luckyvickyauction.core.payment.service.BidHistoryService;
 import com.wootecam.luckyvickyauction.documentation.errorcode.FakeErrorCodeController;
 import com.wootecam.luckyvickyauction.global.config.JsonConfig;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
@@ -41,6 +42,7 @@ public class DocumentationTest {
 
     @MockBean
     protected MemberService memberService;
+
     @MockBean
     protected AuctionService auctionService;
 

--- a/src/test/java/com/wootecam/luckyvickyauction/documentation/ReceiptDocument.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/documentation/ReceiptDocument.java
@@ -1,0 +1,104 @@
+package com.wootecam.luckyvickyauction.documentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+
+import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
+import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSimpleInfo;
+import com.wootecam.luckyvickyauction.core.payment.dto.SellerReceiptSearchCondition;
+import com.wootecam.luckyvickyauction.core.payment.dto.SellerReceiptSimpleInfo;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class ReceiptDocument extends DocumentationTest {
+
+    @Nested
+    class 거래_이력 {
+
+        @Test
+        void 구매자는_정상적으로_거래이력을_확인한다() {
+            SellerReceiptSearchCondition condition = new SellerReceiptSearchCondition(1L, 3);
+            List<BuyerReceiptSimpleInfo> buyerReceiptSimpleInfos = buyerReceiptSimpleInfosSample();
+            given(bidHistoryService.getBuyerReceiptSimpleInfos(any())).willReturn(buyerReceiptSimpleInfos);
+
+            docsGiven.contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(condition)
+                    .when().get("/receipts")
+                    .then().log().all()
+                    .apply(document("receipts/getReceipts/success",
+                            requestFields(
+                                    fieldWithPath("sellerId").type(JsonFieldType.NUMBER)
+                                            .description("거래 내역을 조회할 판매자의 식별자"),
+                                    fieldWithPath("size").type(JsonFieldType.NUMBER)
+                                            .description("조회할 거래 내역의 개수")
+                            )
+                    ))
+                    .statusCode(HttpStatus.OK.value());
+        }
+
+        private List<BuyerReceiptSimpleInfo> buyerReceiptSimpleInfosSample() {
+            List<BuyerReceiptSimpleInfo> buyerReceiptSimpleInfos = new ArrayList<>();
+
+            for (long i = 1; i <= 3; i++) {
+                BuyerReceiptSimpleInfo receipt = BuyerReceiptSimpleInfo.builder()
+                        .id(i)
+                        .auctionId(i)
+                        .price(i * 1000)
+                        .productName("내가 구매한 상품" + i)
+                        .quantity(i * 10)
+                        .type(i % 2 == 1 ? BidStatus.BID : BidStatus.REFUND)
+                        .build();
+                buyerReceiptSimpleInfos.add(receipt);
+            }
+
+            return buyerReceiptSimpleInfos;
+        }
+
+        @Test
+        void 판매자는_정상적으로_거래이력을_확인한다() {
+            SellerReceiptSearchCondition condition = new SellerReceiptSearchCondition(1L, 3);
+            List<SellerReceiptSimpleInfo> sellerReceiptSimpleInfos = sellerReceiptSimpleInfosSample();
+            given(bidHistoryService.getSellerReceiptSimpleInfos(any())).willReturn(sellerReceiptSimpleInfos);
+
+            docsGiven.contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(condition)
+                    .when().get("/receipts/seller")
+                    .then().log().all()
+                    .apply(document("receipts/getSellerReceipts/success",
+                            requestFields(
+                                    fieldWithPath("sellerId").type(JsonFieldType.NUMBER)
+                                            .description("거래 내역을 조회할 판매자의 식별자"),
+                                    fieldWithPath("size").type(JsonFieldType.NUMBER)
+                                            .description("조회할 거래 내역의 개수")
+                            )
+                    ))
+                    .statusCode(HttpStatus.OK.value());
+        }
+
+        private List<SellerReceiptSimpleInfo> sellerReceiptSimpleInfosSample() {
+            List<SellerReceiptSimpleInfo> sellerReceiptSimpleInfos = new ArrayList<>();
+
+            for (long i = 1; i <= 3; i++) {
+                SellerReceiptSimpleInfo receipt = SellerReceiptSimpleInfo.builder()
+                        .id(i)
+                        .auctionId(i)
+                        .price(i * 1000)
+                        .productName("내가 판매한 상품" + i)
+                        .quantity(i * 10)
+                        .type(i % 2 == 0 ? BidStatus.BID : BidStatus.REFUND)
+                        .build();
+                sellerReceiptSimpleInfos.add(receipt);
+            }
+
+            return sellerReceiptSimpleInfos;
+        }
+    }
+}

--- a/src/test/java/com/wootecam/luckyvickyauction/documentation/ReceiptDocument.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/documentation/ReceiptDocument.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.snippet.Attributes.key;
 
 import com.wootecam.luckyvickyauction.core.payment.domain.BidStatus;
 import com.wootecam.luckyvickyauction.core.payment.dto.BuyerReceiptSimpleInfo;
@@ -39,6 +40,7 @@ public class ReceiptDocument extends DocumentationTest {
                                             .description("거래 내역을 조회할 판매자의 식별자"),
                                     fieldWithPath("size").type(JsonFieldType.NUMBER)
                                             .description("조회할 거래 내역의 개수")
+                                            .attributes(key("constraints").value("최소:1 ~ 최대:100"))
                             )
                     ))
                     .statusCode(HttpStatus.OK.value());
@@ -78,6 +80,7 @@ public class ReceiptDocument extends DocumentationTest {
                                             .description("거래 내역을 조회할 판매자의 식별자"),
                                     fieldWithPath("size").type(JsonFieldType.NUMBER)
                                             .description("조회할 거래 내역의 개수")
+                                            .attributes(key("constraints").value("최소:1 ~ 최대:100"))
                             )
                     ))
                     .statusCode(HttpStatus.OK.value());


### PR DESCRIPTION
## 📄 Summary
- ReceiptController 구현
  - 구매자/판매자는 API EndPoint에 요청하여 거래 내역 목록을 조회할 수 있다.
- `BuyerReceiptInfo`에 `ProductName`을 추가한다.
- API 문서 작성
  - [거래 이력](http://localhost:8080/#Receipts)
  - [구매자 거래이력 확인](http://localhost:8080/#_%EA%B5%AC%EB%A7%A4%EC%9E%90_%EA%B1%B0%EB%9E%98%EC%9D%B4%EB%A0%A5_%ED%99%95%EC%9D%B8)
  - [판매자 거래이력 확인](http://localhost:8080/#_%ED%8C%90%EB%A7%A4%EC%9E%90_%EA%B1%B0%EB%9E%98%EC%9D%B4%EB%A0%A5_%ED%99%95%EC%9D%B8)

## 🙋🏻 More

![image](https://github.com/user-attachments/assets/7ec27efe-b05c-4ee9-bd6d-ea551e77d3ee)





close #160