### PR TITLE
feat: 구매자는 REST API를 통해서 경매 목록을 조회할 수 있다. 

### DIFF
--- a/src/docs/asciidoc/auctions.adoc
+++ b/src/docs/asciidoc/auctions.adoc
@@ -1,0 +1,7 @@
+[[Auth]]
+== 경매
+
+=== 목록 조회
+
+==== 구매자
+operation::auctions/getAuctions/success[snippets='http-request,http-response,request-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -8,4 +8,5 @@
 :docinfo: shared-head
 
 include::auth.adoc[]
+include::auctions.adoc[]
 include::errorCode.adoc[]

--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/controller/BuyerAuctionController.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/controller/BuyerAuctionController.java
@@ -3,25 +3,30 @@ package com.wootecam.luckyvickyauction.core.auction.controller;
 import com.wootecam.luckyvickyauction.core.auction.dto.AuctionSearchCondition;
 import com.wootecam.luckyvickyauction.core.auction.dto.BuyerAuctionInfo;
 import com.wootecam.luckyvickyauction.core.auction.dto.BuyerAuctionSimpleInfo;
+import com.wootecam.luckyvickyauction.core.auction.service.AuctionService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-// @RestController  // TODO: [선행 @Repository가 생길 때, 주석을 풀 것] [writeAt: 2024/08/16/16:12] [writeBy: chhs2131]
+@RestController
 @RequestMapping("/auctions")
 @RequiredArgsConstructor
 public class BuyerAuctionController {
 
+    private final AuctionService auctionService;
+
     // 사용자는 경매 목록을 조회한다.
     @GetMapping
-    public List<BuyerAuctionSimpleInfo> getAuctions(@RequestBody AuctionSearchCondition condition) {
-        // TODO: [Task에 맞게 로직 구현할 것!] [writeAt: 2024/08/16/17:40] [writeBy: chhs2131]
-        throw new UnsupportedOperationException();
+    public ResponseEntity<List<BuyerAuctionSimpleInfo>> getAuctions(@RequestBody AuctionSearchCondition condition) {
+        List<BuyerAuctionSimpleInfo> infos = auctionService.getBuyerAuctionSimpleInfos(condition);
+        return ResponseEntity.ok(infos);
     }
 
     // 사용자는 경매의 상세정보를 조회한다.

--- a/src/test/java/com/wootecam/luckyvickyauction/documentation/AuctionDocument.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/documentation/AuctionDocument.java
@@ -1,0 +1,107 @@
+package com.wootecam.luckyvickyauction.documentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+import com.wootecam.luckyvickyauction.core.auction.dto.AuctionSearchCondition;
+import com.wootecam.luckyvickyauction.core.auction.dto.BuyerAuctionSimpleInfo;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class AuctionDocument extends DocumentationTest {
+
+    /**
+     * @see <a href="https://github.com/woowa-techcamp-2024/Team7-ELEVEN/issues/89">Github issue</a>
+     */
+    @Nested
+    class 구매자_경매_목록_조회 {
+
+        @Test
+        void 경매_조회_조건을_전달하면_성공적으로_경매_목록을_반환한다() {
+            AuctionSearchCondition condition = new AuctionSearchCondition(0, 2);
+            List<BuyerAuctionSimpleInfo> infos = buyerAuctionSimpleInfosSample();
+            given(auctionService.getBuyerAuctionSimpleInfos(any())).willReturn(infos);
+
+            docsGiven.contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(condition)
+                    .when().get("/auctions")
+                    .then().log().all()
+                    .apply(document("auctions/getAuctions/success",
+                            requestFields(
+                                    fieldWithPath("offset").type(JsonFieldType.NUMBER)
+                                            .description("조회를 시작할 순서"),
+                                    fieldWithPath("size").type(JsonFieldType.NUMBER)
+                                            .description("조회할 페이지 크기")
+                                            .attributes(key("constraints").value("최소: 1 ~ 최대: 100"))
+                            )
+                    ))
+                    .statusCode(HttpStatus.OK.value());
+        }
+
+        private List<BuyerAuctionSimpleInfo> buyerAuctionSimpleInfosSample() {
+            List<BuyerAuctionSimpleInfo> infos = new ArrayList<>();
+
+            for (long i = 1; i <= 2; i++) {
+                BuyerAuctionSimpleInfo simpleInfo = new BuyerAuctionSimpleInfo(i, "쓸만한 경매품 " + i, i * 2000,
+                        ZonedDateTime.now(), ZonedDateTime.now().plusMinutes(30L));
+                infos.add(simpleInfo);
+            }
+
+            return infos;
+        }
+    }
+
+    /**
+     * @see <a href="https://github.com/woowa-techcamp-2024/Team7-ELEVEN/issues/130">Github issue</a>
+     */
+    // TODO: [판매자 테스트를 먼저 작성해버렸네용 ^^;; 해당 EndPoint 구현시 주석해제하고 활용!] [writeAt: 2024/08/18/15:10] [writeBy: chhs2131]
+//    @Nested
+//    class 판매자_경매_목록_조회 {
+//
+//        @Test
+//        void 경매_조회_조건을_전달하면_성공적으로_경매_목록을_반환한다() {
+//            AuctionSearchCondition condition = new AuctionSearchCondition(10, 2);
+//            List<SellerAuctionSimpleInfo> infos = sellerAuctionSimpleInfosSample();
+//            given(auctionService.getSellerAuctionSimpleInfos(any())).willReturn(infos);
+//
+//            docsGiven.contentType(MediaType.APPLICATION_JSON_VALUE)
+//                    .body(condition)
+//                    .when().get("/auctions/seller")
+//                    .then().log().all()
+//                    .apply(document("auctions/getSellerAuctions/success",
+//                            requestFields(
+//                                    fieldWithPath("offset").type(JsonFieldType.NUMBER)
+//                                            .description("조회를 시작할 순서"),
+//                                    fieldWithPath("size").type(JsonFieldType.NUMBER)
+//                                            .description("조회할 페이지 크기")
+//                                            .attributes(key("constraints").value("최소: 1 ~ 최대: 100"))
+//                            )
+//                    ))
+//                    .statusCode(HttpStatus.OK.value());
+//        }
+//
+//        private List<SellerAuctionSimpleInfo> sellerAuctionSimpleInfosSample() {
+//            List<SellerAuctionSimpleInfo> infos = new ArrayList<>();
+//
+//            for (long i = 1; i <= 2; i++) {
+//                SellerAuctionSimpleInfo simpleInfo = new SellerAuctionSimpleInfo(i, "쓸만한 경매품 " + i, i * 2000,
+//                        i * 2000 - 500, i * 100, i * 30,
+//                        ZonedDateTime.now(), ZonedDateTime.now().plusMinutes(30L));
+//                infos.add(simpleInfo);
+//            }
+//
+//            return infos;
+//        }
+//    }
+
+}

--- a/src/test/java/com/wootecam/luckyvickyauction/documentation/DocumentationTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/documentation/DocumentationTest.java
@@ -3,12 +3,12 @@ package com.wootecam.luckyvickyauction.documentation;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 
+import com.wootecam.luckyvickyauction.core.auction.controller.BuyerAuctionController;
 import com.wootecam.luckyvickyauction.core.auction.controller.SellerAuctionController;
 import com.wootecam.luckyvickyauction.core.auction.service.AuctionService;
 import com.wootecam.luckyvickyauction.core.member.controller.AuthController;
 import com.wootecam.luckyvickyauction.core.member.service.MemberService;
 import com.wootecam.luckyvickyauction.documentation.errorcode.FakeErrorCodeController;
-import com.wootecam.luckyvickyauction.global.config.JsonConfig;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -26,9 +25,9 @@ import org.springframework.web.context.WebApplicationContext;
 @WebMvcTest({
         FakeErrorCodeController.class,
         AuthController.class,
+        BuyerAuctionController.class,
         SellerAuctionController.class
 })
-@Import(JsonConfig.class)
 @ExtendWith(RestDocumentationExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class DocumentationTest {
@@ -37,6 +36,7 @@ public class DocumentationTest {
 
     @MockBean
     protected MemberService memberService;
+
     @MockBean
     protected AuctionService auctionService;
 


### PR DESCRIPTION
## 📄 Summary
- `BuyerAuctionController`의 목록조회 기능 구현
- API 문서 작성

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/03c638a0-2ab1-4ab8-8eb4-0fbb924a1565">

## 🙋🏻 More

머지 되면 세트로 판매자 경매 목록도 올리겠습니다 ㅎㅎ

close #89