### PR TITLE
feat: 경매 삭제 기능 구현 (AuctionCoreRepository)

### DIFF
--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/infra/AuctionCoreRepository.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/infra/AuctionCoreRepository.java
@@ -32,7 +32,7 @@ public class AuctionCoreRepository implements AuctionRepository {
 
     @Override
     public void deleteById(long id) {
-
+        auctionJpaRepository.deleteById(id);
     }
 
     @Override

--- a/src/test/java/com/wootecam/luckyvickyauction/core/auction/infra/AuctionCoreRepositoryTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/auction/infra/AuctionCoreRepositoryTest.java
@@ -7,8 +7,10 @@ import com.wootecam.luckyvickyauction.context.RepositoryTest;
 import com.wootecam.luckyvickyauction.core.auction.domain.Auction;
 import com.wootecam.luckyvickyauction.core.auction.domain.AuctionRepository;
 import com.wootecam.luckyvickyauction.core.auction.domain.ConstantPricePolicy;
+import com.wootecam.luckyvickyauction.core.auction.entity.AuctionEntity;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -180,4 +182,37 @@ class AuctionCoreRepositoryTest extends RepositoryTest {
         }
 
     }
+
+    @Nested
+    class 경매_취소_작업을_수행할_때 {
+
+        @Test
+        void 경매_식별번호가_전달되면_정상적으로_삭제된다() {
+            // given
+            AuctionEntity entity = AuctionEntity.builder().build();
+            AuctionEntity savedAuction = auctionJpaRepository.save(entity);
+
+            // when
+            auctionRepository.deleteById(savedAuction.getId());
+
+            // then
+            List<AuctionEntity> all = auctionJpaRepository.findAll();
+            assertThat(all).isEmpty();
+        }
+
+        @Test
+        void 존재하지않는_경매_식별번호가_전달되면_정상적으로_무시된다() {
+            // given
+            long nonExistentId = 1L;
+
+            // when
+            auctionRepository.deleteById(nonExistentId);
+
+            // then
+            List<AuctionEntity> all = auctionJpaRepository.findAll();
+            assertThat(all).isEmpty();
+        }
+
+    }
+
 }


### PR DESCRIPTION


## 📄 Summary
AuctionCoreRepository의 deleteById 메서드가 빈칸으로 구현되지 않은채 남아있어서 이를 구현합니다~ 

- 경매 삭제 기능 구현 (AuctionCoreRepository)
  - 판매자가 시작전인 경매를 취소할 때 해당 메서드를 활용한다.

## 🙋🏻 More
- 기존 Controller 및 Service는 작성되어있어 그곳에서 호출되는 Repository 측 메서드만 구현하였습니다!



close #238