### PR TITLE
refactor: 사용자 경매 상세 조회시 원래 재고값도 응답하도록 변경합니다.

### DIFF
--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/domain/Product.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/domain/Product.java
@@ -1,4 +1,0 @@
-package com.wootecam.luckyvickyauction.core.auction.domain;
-
-public class Product {
-}

--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/dto/BuyerAuctionInfo.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/dto/BuyerAuctionInfo.java
@@ -1,5 +1,8 @@
 package com.wootecam.luckyvickyauction.core.auction.dto;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.wootecam.luckyvickyauction.core.auction.domain.PricePolicy;
 import com.wootecam.luckyvickyauction.global.exception.BadRequestException;
 import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
@@ -8,7 +11,7 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 
 /**
- * 구매자가 조회할 수 있는 경매 정보 - isShowStock에 따라서 stock 노출 여부가 결정됩니다
+ * 구매자가 조회할 수 있는 경매 정보 - isShowStock에 따라서 currentStock 노출 여부가 결정됩니다
  */
 @Builder
 public record BuyerAuctionInfo(
@@ -17,7 +20,10 @@ public record BuyerAuctionInfo(
         String productName,
         long originPrice,
         long currentPrice,
-        Long stock,
+        @JsonInclude(NON_NULL)
+        Long originStock,
+        @JsonInclude(NON_NULL)
+        Long currentStock,
         long maximumPurchaseLimitCount,
         PricePolicy pricePolicy,
         Duration variationDuration,

--- a/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/util/Mapper.java
@@ -55,7 +55,8 @@ public final class Mapper {
     }
 
     public static BuyerAuctionInfo convertToBuyerAuctionInfo(Auction auction) {
-        Long stock = auction.isShowStock() ? auction.getCurrentStock() : null;
+        Long currentStock = auction.isShowStock() ? auction.getCurrentStock() : null;
+        Long originStock = auction.isShowStock() ? auction.getOriginStock() : null;
 
         return BuyerAuctionInfo.builder()
                 .auctionId(auction.getId())
@@ -63,7 +64,8 @@ public final class Mapper {
                 .productName(auction.getProductName())
                 .originPrice(auction.getOriginPrice())
                 .currentPrice(auction.getCurrentPrice())
-                .stock(stock)
+                .originStock(originStock)
+                .currentStock(currentStock)
                 .maximumPurchaseLimitCount(auction.getMaximumPurchaseLimitCount())
                 .pricePolicy(auction.getPricePolicy())
                 .variationDuration(auction.getVariationDuration())

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -803,14 +803,14 @@ Content-Length: 330
   "id" : 1,
   "title" : "쓸만한 경매품 1",
   "price" : 2000,
-  "startedAt" : "2024-08-22T10:25:21.109182",
-  "finishedAt" : "2024-08-22T10:55:21.109202"
+  "startedAt" : "2024-08-22T11:08:56.156869",
+  "finishedAt" : "2024-08-22T11:38:56.156875"
 }, {
   "id" : 2,
   "title" : "쓸만한 경매품 2",
   "price" : 4000,
-  "startedAt" : "2024-08-22T10:25:21.109261",
-  "finishedAt" : "2024-08-22T10:55:21.109266"
+  "startedAt" : "2024-08-22T11:08:56.156895",
+  "finishedAt" : "2024-08-22T11:38:56.156897"
 } ]</code></pre>
 </div>
 </div>
@@ -931,7 +931,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 367
+Content-Length: 397
 
 {
   "auctionId" : 1,
@@ -939,7 +939,8 @@ Content-Length: 367
   "productName" : "테스트 상품",
   "originPrice" : 10000,
   "currentPrice" : 5000,
-  "stock" : 100,
+  "originStock" : 100,
+  "currentStock" : 100,
   "maximumPurchaseLimitCount" : 10,
   "pricePolicy" : {
     "type" : "CONSTANT",
@@ -1030,10 +1031,17 @@ Content-Length: 367
 <td class="tableblock halign-left valign-top"><p class="tableblock">현재 가격</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>stock</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>originStock</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">재고를 보여주지 않는다면 NULL이고 응답 값에서 제외됨</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">원래 재고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>currentStock</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">재고를 보여주지 않는다면 NULL이고 응답 값에서 제외됨</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">현재 재고</p></td>
 </tr>
 <tr>
@@ -1109,7 +1117,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 369
+Content-Length: 399
 
 {
   "auctionId" : 1,
@@ -1117,7 +1125,8 @@ Content-Length: 369
   "productName" : "테스트 상품",
   "originPrice" : 10000,
   "currentPrice" : 5000,
-  "stock" : 100,
+  "originStock" : 100,
+  "currentStock" : 100,
   "maximumPurchaseLimitCount" : 10,
   "pricePolicy" : {
     "type" : "PERCENTAGE",
@@ -1208,10 +1217,17 @@ Content-Length: 369
 <td class="tableblock halign-left valign-top"><p class="tableblock">현재 가격</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>stock</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>originStock</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">재고를 보여주지 않는다면 NULL이고 응답 값에서 제외됨</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">원래 재고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>currentStock</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">재고를 보여주지 않는다면 NULL이고 응답 값에서 제외됨</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">현재 재고</p></td>
 </tr>
 <tr>
@@ -1294,8 +1310,8 @@ Cookie: JSESSIONID=sessionId
     "variationWidth" : 100
   },
   "variationDuration" : "PT10M",
-  "startedAt" : "2024-08-22T11:25:21.587689",
-  "finishedAt" : "2024-08-22T12:25:21.587689",
+  "startedAt" : "2024-08-22T12:08:56.374419",
+  "finishedAt" : "2024-08-22T13:08:56.374419",
   "isShowStock" : true
 }</code></pre>
 </div>
@@ -1460,8 +1476,8 @@ Cookie: JSESSIONID=sessionId
     "discountRate" : 10.0
   },
   "variationDuration" : "PT10M",
-  "startedAt" : "2024-08-22T11:25:21.547398",
-  "finishedAt" : "2024-08-22T12:25:21.547398",
+  "startedAt" : "2024-08-22T12:08:56.355467",
+  "finishedAt" : "2024-08-22T13:08:56.355467",
   "isShowStock" : true
 }</code></pre>
 </div>
@@ -1702,8 +1718,8 @@ Content-Length: 502
   "currentPrice" : 1500,
   "totalStock" : 100,
   "currentStock" : 30,
-  "startedAt" : "2024-08-22T10:25:21.463633",
-  "finishedAt" : "2024-08-22T10:55:21.463664"
+  "startedAt" : "2024-08-22T11:08:56.318692",
+  "finishedAt" : "2024-08-22T11:38:56.318699"
 }, {
   "id" : 2,
   "title" : "내가 판매하는 경매품 2",
@@ -1711,8 +1727,8 @@ Content-Length: 502
   "currentPrice" : 3500,
   "totalStock" : 200,
   "currentStock" : 60,
-  "startedAt" : "2024-08-22T10:25:21.463766",
-  "finishedAt" : "2024-08-22T10:55:21.463772"
+  "startedAt" : "2024-08-22T11:08:56.318716",
+  "finishedAt" : "2024-08-22T11:38:56.318718"
 } ]</code></pre>
 </div>
 </div>
@@ -1889,8 +1905,8 @@ Content-Length: 420
     "variationWidth" : 10
   },
   "variationDuration" : "PT10M",
-  "startedAt" : "2024-08-22T10:25:21.386677",
-  "finishedAt" : "2024-08-22T11:25:21.386694",
+  "startedAt" : "2024-08-22T11:08:56.283154",
+  "finishedAt" : "2024-08-22T12:08:56.283158",
   "isShowStock" : true
 }</code></pre>
 </div>
@@ -2073,7 +2089,7 @@ Cookie: JSESSIONID=sessionId</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 420
+Content-Length: 421
 
 {
   "auctionId" : 1,
@@ -2088,8 +2104,8 @@ Content-Length: 420
     "discountRate" : 10.0
   },
   "variationDuration" : "PT10M",
-  "startedAt" : "2024-08-22T10:25:21.4263",
-  "finishedAt" : "2024-08-22T11:25:21.426308",
+  "startedAt" : "2024-08-22T11:08:56.29999",
+  "finishedAt" : "2024-08-22T12:08:56.299998",
   "isShowStock" : true
 }</code></pre>
 </div>
@@ -2803,8 +2819,8 @@ Content-Length: 267
   "auctionId" : 1,
   "sellerId" : 1,
   "buyerId" : 2,
-  "createdAt" : "2024-08-22T10:25:21.234861",
-  "updatedAt" : "2024-08-22T11:25:21.234874"
+  "createdAt" : "2024-08-22T11:08:56.227099",
+  "updatedAt" : "2024-08-22T12:08:56.227104"
 }</code></pre>
 </div>
 </div>
@@ -3194,7 +3210,7 @@ Content-Length: 267
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-08-20 18:59:39 +0900
+Last updated 2024-08-20 17:53:19 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/wootecam/luckyvickyauction/core/auction/dto/BuyerAuctionInfoTest.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/auction/dto/BuyerAuctionInfoTest.java
@@ -22,16 +22,19 @@ public class BuyerAuctionInfoTest {
     static Stream<Arguments> auctionInfoDtoArguments() {
         return Stream.of(
                 Arguments.of("상품 이름은 비어있을 수 없습니다.",
-                        ErrorCode.A001, 1L, 1L, "", 10000, 10000, 10, 10, Duration.ofMinutes(1L), LocalDateTime.now(),
+                        ErrorCode.A001, 1L, 1L, "", 10000, 10000, 10000, 10, 10, Duration.ofMinutes(1L),
+                        LocalDateTime.now(),
                         LocalDateTime.now()),
                 Arguments.of("상품 원가는 0보다 커야 합니다. 상품 원가: 0",
-                        ErrorCode.A002, 1L, 1L, "상품이름", 0, 10000, 10, 10, Duration.ofMinutes(1L), LocalDateTime.now(),
+                        ErrorCode.A002, 1L, 1L, "상품이름", 0, 10000, 10000, 10, 10, Duration.ofMinutes(1L),
+                        LocalDateTime.now(),
                         LocalDateTime.now()),
                 Arguments.of("현재 가격은 0보다 커야 합니다. 현재 가격: 0",
-                        ErrorCode.A011, 1L, 1L, "상품이름", 10000, 0, 10, 10, Duration.ofMinutes(1L), LocalDateTime.now(),
+                        ErrorCode.A011, 1L, 1L, "상품이름", 10000, 0, 10000, 10, 10, Duration.ofMinutes(1L),
+                        LocalDateTime.now(),
                         LocalDateTime.now()),
                 Arguments.of("최대 구매 수량 제한은 0보다 커야 합니다. 최대 구매 수량 제한: 0",
-                        ErrorCode.A003, 1L, 1L, "상품이름", 10000, 10000, 10, 0, Duration.ofMinutes(1L),
+                        ErrorCode.A003, 1L, 1L, "상품이름", 10000, 10000, 10000, 10, 0, Duration.ofMinutes(1L),
                         LocalDateTime.now(), LocalDateTime.now())
         );
     }
@@ -44,7 +47,8 @@ public class BuyerAuctionInfoTest {
         String productName = "상품이름";
         long originPrice = 10000;
         long currentPrice = 10000;
-        long stock = 10;
+        long originStock = 10;
+        long currentStock = 10;
         int maximumPurchaseLimitCount = 10;
 
         int variationWidth = 1000;
@@ -56,7 +60,7 @@ public class BuyerAuctionInfoTest {
 
         // when
         BuyerAuctionInfo buyerAuctionInfo = new BuyerAuctionInfo(auctionId, sellerId, productName, originPrice,
-                currentPrice, stock,
+                currentPrice, originStock, currentStock,
                 maximumPurchaseLimitCount, pricePolicy, varitationDuration, startedAt, finishedAt);
 
         // then
@@ -66,7 +70,8 @@ public class BuyerAuctionInfoTest {
                 () -> assertThat(buyerAuctionInfo.productName()).isEqualTo(productName),
                 () -> assertThat(buyerAuctionInfo.originPrice()).isEqualTo(originPrice),
                 () -> assertThat(buyerAuctionInfo.currentPrice()).isEqualTo(currentPrice),
-                () -> assertThat(buyerAuctionInfo.stock()).isEqualTo(stock),
+                () -> assertThat(buyerAuctionInfo.originStock()).isEqualTo(originStock),
+                () -> assertThat(buyerAuctionInfo.currentStock()).isEqualTo(currentStock),
                 () -> assertThat(buyerAuctionInfo.maximumPurchaseLimitCount()).isEqualTo(maximumPurchaseLimitCount),
                 () -> assertThat(buyerAuctionInfo.pricePolicy()).isEqualTo(pricePolicy),
                 () -> assertThat(buyerAuctionInfo.variationDuration()).isEqualTo(varitationDuration),
@@ -112,7 +117,7 @@ public class BuyerAuctionInfoTest {
         BuyerAuctionInfo buyerAuctionInfo = Mapper.convertToBuyerAuctionInfo(auction);
 
         // then
-        assertThat(buyerAuctionInfo.stock()).isEqualTo(null);
+        assertThat(buyerAuctionInfo.currentStock()).isEqualTo(null);
     }
 
     @ParameterizedTest
@@ -125,7 +130,8 @@ public class BuyerAuctionInfoTest {
             String productName,
             long originPrice,
             long currentPrice,
-            long stock,
+            long originStock,
+            long currentStock,
             int maximumPurchaseLimitCount,
             Duration variationDuration,
             LocalDateTime startedAt,
@@ -138,7 +144,8 @@ public class BuyerAuctionInfoTest {
                 .productName(productName)
                 .originPrice(originPrice)
                 .currentPrice(currentPrice)
-                .stock(stock)
+                .originStock(originStock)
+                .currentStock(currentStock)
                 .maximumPurchaseLimitCount(maximumPurchaseLimitCount)
                 .pricePolicy(PricePolicy.createConstantPricePolicy(1000))
                 .variationDuration(variationDuration)

--- a/src/test/java/com/wootecam/luckyvickyauction/core/auction/fixture/BuyerAuctionInfoFixture.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/core/auction/fixture/BuyerAuctionInfoFixture.java
@@ -11,7 +11,8 @@ public class BuyerAuctionInfoFixture {
     private String productName = "테스트 상품";
     private long originPrice = 10000;
     private long currentPrice = 5000;
-    private Long stock = 100L;
+    private long originStock = 100L;
+    private Long currentStock = 100L;
     private long maximumPurchaseLimitCount = 10;
     private PricePolicy pricePolicy = PricePolicy.createPercentagePricePolicy(10);
     private Duration variationDuration = Duration.ofMinutes(1L);
@@ -47,8 +48,13 @@ public class BuyerAuctionInfoFixture {
         return this;
     }
 
-    public BuyerAuctionInfoFixture stock(Long stock) {
-        this.stock = stock;
+    public BuyerAuctionInfoFixture originStock(Long originStock) {
+        this.originStock = originStock;
+        return this;
+    }
+
+    public BuyerAuctionInfoFixture currentStock(Long currentStock) {
+        this.currentStock = currentStock;
         return this;
     }
 
@@ -84,7 +90,8 @@ public class BuyerAuctionInfoFixture {
                 productName,
                 originPrice,
                 currentPrice,
-                stock,
+                originStock,
+                currentStock,
                 maximumPurchaseLimitCount,
                 pricePolicy,
                 variationDuration,

--- a/src/test/java/com/wootecam/luckyvickyauction/documentation/BuyerAuctionDocument.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/documentation/BuyerAuctionDocument.java
@@ -1,5 +1,6 @@
 package com.wootecam.luckyvickyauction.documentation;
 
+import static com.wootecam.luckyvickyauction.documentation.DocumentFormatGenerator.getAttribute;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -122,7 +123,10 @@ class BuyerAuctionDocument extends DocumentationTest {
                                     fieldWithPath("productName").description("상품 이름"),
                                     fieldWithPath("originPrice").description("상품 원가"),
                                     fieldWithPath("currentPrice").description("현재 가격"),
-                                    fieldWithPath("stock").description("현재 재고"),
+                                    fieldWithPath("originStock").description("원래 재고").attributes(
+                                            getAttribute("format", "재고를 보여주지 않는다면 NULL이고 응답 값에서 제외됨")),
+                                    fieldWithPath("currentStock").description("현재 재고").attributes(
+                                            getAttribute("format", "재고를 보여주지 않는다면 NULL이고 응답 값에서 제외됨")),
                                     fieldWithPath("maximumPurchaseLimitCount").description("최대 구매 수량 제한"),
                                     fieldWithPath("pricePolicy").description("가격 정책"),
                                     fieldWithPath("pricePolicy.type").description("가격 정책 타입"),
@@ -160,7 +164,10 @@ class BuyerAuctionDocument extends DocumentationTest {
                                     fieldWithPath("productName").description("상품 이름"),
                                     fieldWithPath("originPrice").description("상품 원가"),
                                     fieldWithPath("currentPrice").description("현재 가격"),
-                                    fieldWithPath("stock").description("현재 재고"),
+                                    fieldWithPath("originStock").description("원래 재고").attributes(
+                                            getAttribute("format", "재고를 보여주지 않는다면 NULL이고 응답 값에서 제외됨")),
+                                    fieldWithPath("currentStock").description("현재 재고").attributes(
+                                            getAttribute("format", "재고를 보여주지 않는다면 NULL이고 응답 값에서 제외됨")),
                                     fieldWithPath("maximumPurchaseLimitCount").description("최대 구매 수량 제한"),
                                     fieldWithPath("pricePolicy").description("가격 정책"),
                                     fieldWithPath("pricePolicy.type").description("가격 정책 타입"),

--- a/src/test/java/com/wootecam/luckyvickyauction/documentation/DocumentFormatGenerator.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/documentation/DocumentFormatGenerator.java
@@ -6,7 +6,7 @@ import org.springframework.restdocs.snippet.Attributes;
 
 public class DocumentFormatGenerator {
 
-    public static Attributes.Attribute getConstraints(final String key, final String value) {
+    public static Attributes.Attribute getAttribute(final String key, final String value) {
         return key(key).value(value);
     }
 }

--- a/src/test/java/com/wootecam/luckyvickyauction/documentation/PaymentDocument.java
+++ b/src/test/java/com/wootecam/luckyvickyauction/documentation/PaymentDocument.java
@@ -1,6 +1,6 @@
 package com.wootecam.luckyvickyauction.documentation;
 
-import static com.wootecam.luckyvickyauction.documentation.DocumentFormatGenerator.getConstraints;
+import static com.wootecam.luckyvickyauction.documentation.DocumentFormatGenerator.getAttribute;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -42,7 +42,7 @@ class PaymentDocument extends DocumentationTest {
                         ),
                         requestFields(
                                 fieldWithPath("amount").type(JsonFieldType.NUMBER).description("충전할 포인트 금액")
-                                        .attributes(getConstraints("constraints", "Long.MAX_VALUE까지 충전 가능"))
+                                        .attributes(getAttribute("constraints", "Long.MAX_VALUE까지 충전 가능"))
                         )
                 ))
                 .andExpect(status().isOk());


### PR DESCRIPTION

## 📄 Summary
- `BuyerAuctionInfo` 수정 사항
  - 재고 정보(originStock, currentStock는 null인 경우 응답값에서 제외합니다.
  - API 문서 업데이트

## 🙋🏻 More


close #263