### PR TITLE
bug: 거래 내역은 환불 시에 경매 식별자를 가져야 한다

### DIFF
--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/service/auctioneer/BasicAuctioneer.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/service/auctioneer/BasicAuctioneer.java
@@ -48,6 +48,7 @@ public class BasicAuctioneer implements Auctioneer {
                 .receiptStatus(ReceiptStatus.PURCHASED)
                 .sellerId(savedSeller.getId())
                 .buyerId(savedBuyer.getId())
+                .auctionId(auctionId)
                 .build();
         receiptRepository.save(receipt);
     }


### PR DESCRIPTION
## 📄 Summary

- 거래 내역 생성 경매 식별자가 들어가지 않는 버그를 해결합니다

## 🙋🏻 More

최초 1줄 PR!


close #280