### PR TITLE
fix: 영수증 응답을 답는 DTO의 Key이름을 서버와 동일하게 수정

### DIFF
--- a/front/src/api/auction/api.ts
+++ b/front/src/api/auction/api.ts
@@ -86,7 +86,7 @@ async function requestAuctionBid(
                 onFailure(`Error: ${bidResponse.message}`);
             } else {
                 // Success handling
-                onSuccess(bidResponse.uuid);
+                onSuccess(bidResponse.receiptId);
             }
         } else {
             const errorMessage = await response.text();

--- a/front/src/api/auction/type.ts
+++ b/front/src/api/auction/type.ts
@@ -6,7 +6,7 @@ interface AuctionsRequest {
 }
 
 interface AuctionBidResponse {
-    uuid: number;
+    receiptId: number;
     message: string;
     errorCode: string;
 }


### PR DESCRIPTION
## 📄 Summary

영수증 응답을 답는 DTO의 Key이름을 서버와 동일하게 수정

## 🙋🏻 More

서버에서 응답해주는 KEY와 클라이언트에서 UUID를 담는 키가 달라 오류가 낫었습니다. 

close #front