### PR TITLE
chore: redisson lease time 200초 설정

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,10 +37,10 @@ lock:
   lettuce:
     max_retry: 10
     retry_duration: 50
-    lease_time: 200
+    lease_time: 200000
   redisson:
     wait_time: 500
-    lease_time: 200
+    lease_time: 200000
 
 stream:
   key: LVA-Stream


### PR DESCRIPTION
## ❌ Problem
분산락의 TTL이 로직의 실행 시간보다 적은 경우에는 동시성 이슈가 발생하기 때문에 테스트 시나리오에서 이를 검증하기 위해서 TTL을 200초로 설정합니다.

## 📄 Summary

- 분산락의 TTL을 200ms에서 200s 로 설정합니다.
- 경매 입찰 로직이 처리되는 실행 시간을 측정합니다.

## 🙋🏻 More

![image](https://github.com/user-attachments/assets/783d823f-8091-440f-8234-5362cc261739)

평균 5ms

![image](https://github.com/user-attachments/assets/23bedcda-7e7b-45d7-abb8-6264b181683d)

![image](https://github.com/user-attachments/assets/cd41d9ce-cc01-44f9-be2f-5cc81deab3de)