### PR TITLE
fix: Reddison Lock을 얻을 때 타임아웃이 발생한다면 unlock을 호출하지 않도록 한다.

### DIFF
--- a/core/src/main/java/com/wootecam/luckyvickyauction/aop/DistributedLockAspect.java
+++ b/core/src/main/java/com/wootecam/luckyvickyauction/aop/DistributedLockAspect.java
@@ -23,8 +23,8 @@ public class DistributedLockAspect {
     public Object around(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
         String key = getLockName(joinPoint, distributedLock);
 
+        lockProvider.tryLock(key);
         try {
-            lockProvider.tryLock(key);
             return joinPoint.proceed();
         } finally {
             lockProvider.unlock(key);


### PR DESCRIPTION
## 📄 Summary

락을 얻지 못한다면 tryLock에서 대기하다가 타임아웃이 끝나면 예외가 발생합니다. 따라서 무조건적으로 finally를 호출하게 되는데 이때 락을 얻지 못한 상태에서 호출한다면 IllegalMonitorStateException이 발생합니다.

따라서 try-catch문 바깥에서 Lock을 얻도록 변경합니다.

## 🙋🏻 More

close #343