### PR TITLE
feat: 분산락 타임아웃 상황에서 트랜잭션 롤백 문제 해결

### DIFF
--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -27,5 +27,5 @@ jobs:
           cache: gradle
 
       - name: Run tests
-        run: ./gradlew clean test --info
+        run: ./gradlew clean test
 

--- a/src/main/java/com/wootecam/luckyvickyauction/core/auction/service/auctioneer/BasicAuctioneer.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/auction/service/auctioneer/BasicAuctioneer.java
@@ -10,6 +10,7 @@ import com.wootecam.luckyvickyauction.core.payment.domain.ReceiptRepository;
 import com.wootecam.luckyvickyauction.core.payment.domain.ReceiptStatus;
 import com.wootecam.luckyvickyauction.core.payment.service.PaymentService;
 import com.wootecam.luckyvickyauction.global.aop.DistributedLock;
+import com.wootecam.luckyvickyauction.global.aop.TransactionalTimeout;
 import com.wootecam.luckyvickyauction.global.dto.AuctionPurchaseRequestMessage;
 import com.wootecam.luckyvickyauction.global.dto.AuctionRefundRequestMessage;
 import com.wootecam.luckyvickyauction.global.exception.AuthorizationException;
@@ -38,7 +39,7 @@ public class BasicAuctioneer implements Auctioneer {
      * 성공하면 -> Receipt 저장 및 구매자, 판매자 업데이트 적용
      */
     @Override
-    @Transactional
+    @TransactionalTimeout
     @Timed("purchase_process_time")
     @DistributedLock("#message.auctionId + ':auction:lock'")
     public void process(AuctionPurchaseRequestMessage message) {

--- a/src/main/java/com/wootecam/luckyvickyauction/core/payment/service/PaymentService.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/core/payment/service/PaymentService.java
@@ -4,6 +4,7 @@ import com.wootecam.luckyvickyauction.core.member.domain.Member;
 import com.wootecam.luckyvickyauction.core.member.domain.MemberRepository;
 import com.wootecam.luckyvickyauction.core.member.dto.SignInInfo;
 import com.wootecam.luckyvickyauction.global.aop.DistributedLock;
+import com.wootecam.luckyvickyauction.global.aop.TransactionalTimeout;
 import com.wootecam.luckyvickyauction.global.exception.BadRequestException;
 import com.wootecam.luckyvickyauction.global.exception.ErrorCode;
 import com.wootecam.luckyvickyauction.global.exception.NotFoundException;
@@ -31,7 +32,7 @@ public class PaymentService {
         memberRepository.save(member);
     }
 
-    @Transactional
+    @TransactionalTimeout
     @DistributedLock("#recipientId + ':point:lock'")
     public void pointTransfer(long senderId, long recipientId, long amount) {
         Member sender = findMemberObject(senderId);

--- a/src/main/java/com/wootecam/luckyvickyauction/global/aop/DistributedLockAspect.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/aop/DistributedLockAspect.java
@@ -23,8 +23,8 @@ public class DistributedLockAspect {
     public Object around(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
         String key = getLockName(joinPoint, distributedLock);
 
+        lockProvider.tryLock(key);
         try {
-            lockProvider.tryLock(key);
             return joinPoint.proceed();
         } finally {
             lockProvider.unlock(key);

--- a/src/main/java/com/wootecam/luckyvickyauction/global/aop/TransactionalTimeout.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/aop/TransactionalTimeout.java
@@ -1,0 +1,12 @@
+package com.wootecam.luckyvickyauction.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TransactionalTimeout {
+    //    int timeoutMillis() default 60000;
+}

--- a/src/main/java/com/wootecam/luckyvickyauction/global/aop/TransactionalTimeoutAspect.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/aop/TransactionalTimeoutAspect.java
@@ -43,9 +43,12 @@ public class TransactionalTimeoutAspect {
                 }
 
                 return result;  // 정상 수행한 결과 반환
-            } catch (Throwable throwable) {
+            } catch (RuntimeException ex) {
                 status.setRollbackOnly();
-                throw new RuntimeException(throwable);
+                throw ex;
+            } catch (Throwable e) {
+                log.error("message={}", e.getMessage(), e);
+                throw new RuntimeException("처리할 수 없습니다.");
             }
         });
     }

--- a/src/main/java/com/wootecam/luckyvickyauction/global/aop/TransactionalTimeoutAspect.java
+++ b/src/main/java/com/wootecam/luckyvickyauction/global/aop/TransactionalTimeoutAspect.java
@@ -1,0 +1,53 @@
+package com.wootecam.luckyvickyauction.global.aop;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Order(2)
+public class TransactionalTimeoutAspect {
+
+    private static final int TIMEOUT_MARGIN = 100;
+    private final TransactionTemplate transactionTemplate;
+
+    @Value("${lock.redisson.lease_time: 500}")
+    private int leaseTime;  // TODO: [시간을 초기화하고 보관하는 Bean을 별도로 만들어 관리하기] [writeAt: 2024/08/29/17:27] [writeBy: chhs2131]
+
+    @Around("@annotation(transactionalTimeout)")
+    public Object handleCustomTransaction(ProceedingJoinPoint joinPoint, TransactionalTimeout transactionalTimeout) {
+        long startTime = System.currentTimeMillis();
+        long timeoutMillis = leaseTime - TIMEOUT_MARGIN;
+
+        return transactionTemplate.execute((TransactionStatus status) -> {
+            try {
+                Object result = joinPoint.proceed();
+                long elapsedTime = System.currentTimeMillis() - startTime;
+
+                if (elapsedTime > timeoutMillis) {
+                    log.debug("트랜잭션 타임아웃을 초과했습니다. 초과시간: {}ms", elapsedTime - timeoutMillis);
+                    status.setRollbackOnly();
+                    throw new RuntimeException(
+                            "Transaction timed out after " + elapsedTime + " ms. Timeout was set to " + timeoutMillis
+                                    + " ms.");
+                }
+
+                return result;  // 정상 수행한 결과 반환
+            } catch (Throwable throwable) {
+                status.setRollbackOnly();
+                throw new RuntimeException(throwable);
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
## 📄 Summary
레디슨락의 LeaseTime을 초과하여 중도 반환하였으나, 어플리케이션 로직 진행 중에는 이를 인지하지 못하고 있게 된다.
트랜잭션 Commit 이후 레디슨락을 unlcok하는 시점에서 이를 발견하고 익셉션이 발생하는 경우, 트랜잭션이 롤백되지 않아 데이터 정합성 문제가 발생한다.

### 문제 그림
<img width="716" alt="image" src="https://github.com/user-attachments/assets/cf1abdd8-317c-49ed-a4ff-edda3390d6c5">


<br/>
<br/>

### 할일 
- 타이머를 통해 락을 관리한다.
- TransactionalWithTimer 추가  
  - 기존 트랜잭셔널에 타임아웃 값이 있다. 이걸 활용해보자! 
  - https://blog.outsider.ne.kr/870
- Sleep줘서 테스트 확인해보기 
  - 테스트 상황 가정: 분산락 lease time을 초과하는 입찰 로직은 정상적으로 실패하고 롤백된다.
    - 한명의 유저가 입찰 로직을 시작
    - Lock 획득
    - 트랜잭션 시작
    - 입찰 작업이 너무 길어져 Lock lease time을 초과함 (즉, 락을 이 시점에서 잃음)
    - 트랜잭션 타임아웃으로 인해 트랜잭션이 종료됨 
    - Lock 반환에 실패하고 예외 발생 (lease time 초과 시점에서 이미 반환됨)

<br/>
<br/>

![image](https://github.com/user-attachments/assets/58a95d39-1eb6-4859-b922-44b5603ae396)

<br/>
<br/>

## 🙋🏻 More

>


close #342