### PR TITLE
[DEV1] chore: redisson lease time 160ms 설정 waiting time 1.5s 설정

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,10 +37,10 @@ lock:
   lettuce:
     max_retry: 10
     retry_duration: 50
-    lease_time: 200000
+    lease_time: 160
   redisson:
-    wait_time: 500
-    lease_time: 200000
+    wait_time: 1500
+    lease_time: 160
 
 stream:
   key: LVA-Stream


### PR DESCRIPTION
## 📄 Summary

- redisson lock time out 160ms
- application timeout 60ms
- lock waiting timeout 1500ms

## 🙋🏻 More

>
